### PR TITLE
__getitem__ for 0d variables returns 0d arrays (not 1d arrays)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,11 @@
  version 1.0.9 (not yet released)
  ================================
 
+ * accessing values from a 0-dimensional Variable now returns a 0-dimensional
+   numpy array, not a 1-dimensional array (issue 220). To write code
+   compatible with both the old and new (fixed) behavior, wrap values accessed
+   from a 0-dimensional Variable with numpy.asscalar.
+
  * add an __array__ method to Variable to make numpy ufuncs faster (issue 216).
 
  * change download_url in setup.py to point to pypi instead of googlecode.

--- a/netCDF4.pyx
+++ b/netCDF4.pyx
@@ -2852,8 +2852,8 @@ rename a L{Variable} attribute named C{oldname} to C{newname}."""
         if hasattr(data,'shape'):
             data = data[tuple(squeeze)]
         if self.ndim == 0:
-            # this hack compensates for hack at the start of
-            # netCDF4_utils._StartCountStride that makes all 0d arrays 1d.
+            # Make sure a numpy scalar is returned instead of a 1-d array of
+            # length 1.
             data = data[0]
 
         # if auto_maskandscale mode set to True, (through

--- a/test/tst_slicing.py
+++ b/test/tst_slicing.py
@@ -92,6 +92,7 @@ class VariablesTestCase(unittest.TestCase):
         v = f.createVariable('data', float)
         v[...] = 10
         assert_array_equal(v[...], 10)
+        assert_equal(v.shape, v[...].shape)
         f.close()
  
 


### PR DESCRIPTION
This fix ensures that indexing a 0-dimensional Variable returns a 0-dimensional
numpy array (consistent with numpy's behavior), not a 1-dimensional array with
one element, which is the current behavior.

I'm sure there is a more elegant solution to this issue, but I think this is
one of the better options short of rewriting the core indexing routines. As an
alternative, I did try removing the hack `if nDims == 0: ...` at the start of
_StartCountStride but that definitely broke things. Presumably that hack is
there for a reason?

Note that to fully match how numpy handles 0-dimensional arrays, we would
actually raise an error when somebody tries to access or set a 0-dimensional
variable with `v[:]`. The right syntax for indexing a 0-dimensional array is
somewhat obscure: `v[()]` (using an empty tuple) or `v[...]`. But I avoided
this option because it would assuredly break some user code.

My fix here will probably break some poorly constructed user code, too, if it
relied on the broken 0-d arrays are always 1-d behavior (the right way to
handle that would have been to use `np.asscalar`). So there may be a case for
saving this until the next major version.
