### PR TITLE
Add .travis.yml for Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+notifications:
+  email: false
+before_install:
+  - sudo apt-get install libhdf5-serial-dev netcdf-bin libnetcdf-dev
+  - pip install numpy cython python-dateutil
+install:
+  - pip install .
+script:
+  - nosetests test/tst*py


### PR DESCRIPTION
This is most of the work of setting up Travis-CI as I suggest in #225.

Almost all tests pass with this configuration file:
https://travis-ci.org/shoyer/netcdf4-python/builds/20191174

The "testing diskless file capability" test requires a newer build of the
netCDF4 library than is available pre-built for Ubuntu, so it's not surprise
it fails (I suppose we really ought to build the netCDF library from source).

As for the "testing unicode" test on Python 2.7, that also fails when I run
the test suite locally on laptop.
