### PR TITLE
Replace zip with itertools.izip under Python 2

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -29,6 +29,8 @@
    mix of pointers and values). Each pointer declaration should be on its own
    line") with Cython 0.2.
 
+ * reduced memory usage for Variable.__getitem__ under Python 2.
+
  version 1.0.8 (tag v1.0.8rel)
  =============================
 

--- a/netCDF4.pyx
+++ b/netCDF4.pyx
@@ -802,6 +802,11 @@ except ImportError: # or else use drop-in substitute
         from ordereddict import OrderedDict
     except ImportError:
         raise ImportError('please install ordereddict (https://pypi.python.org/pypi/ordereddict)')
+try:
+    from itertools import izip as zip
+except ImportError:
+    # python3: zip is already python2's itertools.izip
+    pass
 
 __version__ = "1.0.9"
 


### PR DESCRIPTION
This reduces the amount of memory required for complicated calls to
`Variable.__getitem__` under array indexers, which iterates over all
indexers with "zip".

netCDF4-python's handling of array indexers is still very complicated/slow
when there are multiple array indexers involved, but this at least improves
the situation.
