### PR TITLE
Switch from using datatype.str[2:] to datatype.itemsize

### DIFF
--- a/netCDF4.pyx
+++ b/netCDF4.pyx
@@ -2290,7 +2290,7 @@ instance. If C{None}, the data is not truncated. """
         # convert numpy string dtype with length > 1 
         # or any numpy unicode dtype into str
         if (isinstance(datatype, numpy.dtype) and
-            ((datatype.kind == 'S' and int(datatype.str[2:]) > 1) or
+            ((datatype.kind == 'S' and datatype.itemsize > 1) or
               datatype.kind == 'U')):
             datatype = str
 	# check if endian keyword consistent with datatype specification.


### PR DESCRIPTION
This couples us less heavily to the numpy dtype string representation. Also,
it might be possible to have numpy strings which don't specify a byte order?
I'm not sure, but this is cleaner code in any case.
