### PR TITLE
Update DAP test - file not present

### DIFF
--- a/test/tst_dap.py
+++ b/test/tst_dap.py
@@ -3,11 +3,11 @@ import netCDF4
 
 # test accessing data over http with opendap.
 
-URL = 'http://test.opendap.org/opendap/hyrax/data/nc/testfile.nc'
-firstvarname = 'aa'
-firstvarmin = -2
-firstvarmax = -0
-firstvarshape = (4,)
+URL = 'http://test.opendap.org/opendap/hyrax/data/nc/bears.nc'
+firstvarname = 'i'
+firstvarmin = 10
+firstvarmax = 20
+firstvarshape = (2,)
 
 class DapTestCase(unittest.TestCase):
 


### PR DESCRIPTION
`testfile.nc` appears to have gone walkabout. Using `bears.nc` instead makes the test work.
