### PR TITLE
Allow setup.py/pip to run query commands without needing numpy.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
-import os, sys, subprocess, numpy, shutil
-from distutils.core  import setup, Extension
+import os, sys, subprocess, shutil
+try:
+    from setuptools import setup, Extension
+except ImportError:
+    from distutils.core  import setup, Extension
+from distutils.dist import Distribution
 try:
     from Cython.Distutils import build_ext
     has_cython = True
@@ -285,8 +289,15 @@ NETCDF4_DIR environment variable not set, checking standard locations.. \n""")
         lib_dirs.append(curl_libdir)
         inc_dirs.append(curl_incdir)
 
-# append numpy include dir.
-inc_dirs.append(numpy.get_include())
+# Do not require numpy for just querying the package
+# Taken from the h5py setup file.
+if any('--' + opt in sys.argv for opt in Distribution.display_option_names +
+       ['help-commands', 'help']) or sys.argv[1] == 'egg_info':
+    pass
+else:
+    # append numpy include dir.
+    import numpy
+    inc_dirs.append(numpy.get_include())
 
 # get netcdf library version.
 netcdf_lib_version = getnetcdfvers(lib_dirs)


### PR DESCRIPTION
pip downloads and queries packages first, before trying to build them. In a clean environment, numpy is missing and any query therefore fails, though the build could actually proceed (provided numpy is built and installed first).
A conditional import depending on the setup command used can prevent pip from failing on the installation.

In particular, this can be an issue when [tox](https://testrun.org/tox/latest/) is used for automated testing: tox sets up a virtualenv without numpy, uses pip to download and query netCDF4 (`python setup.py egg_info`) and then fails during that inquiry since numpy is required, even if numpy is listed first in `tox.ini` and will be installed before netCDF4.

Note: the current solution still poses problems when running `python setup.py` manually and using an invalid command: instead of letting distutils/setuptools point out the invalid command to the user, an `ImportError` is raised for a missing numpy.
