### PR TITLE
stripped string after since to remove leading spaces

### DIFF
--- a/netcdftime.py
+++ b/netcdftime.py
@@ -531,7 +531,7 @@ def _dateparse(timestr):
         raise ValueError("no 'since' in unit_string")
     # parse the date string.
     n = timestr.find('since')+6
-    year,month,day,hour,minute,second,utc_offset = _parse_date(timestr[n:])
+    year,month,day,hour,minute,second,utc_offset = _parse_date(timestr[n:].strip())
     return units, utc_offset, datetime(year, month, day, hour, minute, second)
 
 class utime:

--- a/test/tst_netcdftime.py
+++ b/test/tst_netcdftime.py
@@ -23,6 +23,7 @@ class netcdftimeTestCase(unittest.TestCase):
         self.cdftime_360day = utime('days since 1600-02-30 00:00:00',calendar='360_day')
         self.cdftime_jul = utime('hours since 1000-01-01 00:00:00',calendar='julian')
         self.cdftime_iso = utime("seconds since 1970-01-01T00:00:00Z")
+	self.cdftime_leading_space = utime("days since  850-01-01 00:00:00")
 
     def runTest(self):
         """testing netcdftime"""
@@ -227,6 +228,8 @@ class netcdftimeTestCase(unittest.TestCase):
         with self.assertRaises(AttributeError):
             d1.format = '%Y'
 
+	# Check leading white space
+	self.assertEqual(repr(self.cdftime_leading_space.origin), ' 850-01-01 00:00:00')
 
 class TestDate2index(unittest.TestCase):
 


### PR DESCRIPTION
Test added. There is one (unrelated ? error) in tst_netcdftime. 

```
======================================================================
ERROR: test_select_nc (__main__.TestDate2index)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/tst_netcdftime.py", line 387, in test_select_nc
    millisecs = int(date2num(d,unix_epoch,calendar='proleptic_gregorian'))
  File "utils.pyx", line 124, in netCDF4.date2num (netCDF4.c:4098)
    basedate = _dateparse(units)
  File "utils.pyx", line 21, in netCDF4._dateparse (netCDF4.c:2901)
    basedate = dparse.parse(isostring)
  File "/usr/local/Python271_so/lib/python2.7/site-packages/dateutil/parser.py", line 698, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/usr/local/Python271_so/lib/python2.7/site-packages/dateutil/parser.py", line 302, in parse
    res = self._parse(timestr, **kwargs)
  File "/usr/local/Python271_so/lib/python2.7/site-packages/dateutil/parser.py", line 350, in _parse
    l = _timelex.split(timestr)
  File "/usr/local/Python271_so/lib/python2.7/site-packages/dateutil/parser.py", line 144, in split
    return list(cls(s))
  File "/usr/local/Python271_so/lib/python2.7/site-packages/dateutil/parser.py", line 44, in __init__
    instream = StringIO(instream)
TypeError: initial_value must be unicode or None, not str
```
