### PR TITLE
fix failed run of test that passes Travis CI

### DIFF
--- a/test/run_all.py
+++ b/test/run_all.py
@@ -31,12 +31,12 @@ def test(verbosity=1):
 
 if __name__ == '__main__':
     import numpy
-    runner = unittest.TextTestRunner(verbosity=1)
-    result = runner.run(testsuite)
     sys.stdout.write('\n')
     sys.stdout.write('netcdf4-python version: %s\n' % __version__)
     sys.stdout.write('HDF5 lib version:       %s\n' % __hdf5libversion__)
     sys.stdout.write('netcdf lib version:     %s\n' % __netcdf4libversion__)
     sys.stdout.write('numpy version           %s\n' % numpy.__version__)
+    runner = unittest.TextTestRunner(verbosity=1)
+    result = runner.run(testsuite)
     if not result.wasSuccessful():
         sys.exit(1)


### PR DESCRIPTION
It could happen that the tests failed but Travis CI did not recognize
it. The success of the test suite is now checked explicitly.

For example of failed test that passed CI build see -> https://travis-ci.org/shoyer/netcdf4-python/jobs/40971359
