### PR TITLE
Fix IndexError: invalid index to scalar variable

### DIFF
--- a/netcdftime/netcdftime.py
+++ b/netcdftime/netcdftime.py
@@ -265,9 +265,9 @@ def DateFromJulianDay(JD, calendar='standard'):
     # MC
     # C = int((B - 122.1)/365.25)
     # D = int(365.25 * C)
-    C = np.int32(6680. + ((B - 2439870.) - 122.1) / 365.25)
-    D = np.int32(365 * C + np.int32(0.25 * C))
-    E = np.int32((B - D) / 30.6001)
+    C = np.atleast_1d(np.int32(6680. + ((B - 2439870.) - 122.1) / 365.25))
+    D = np.atleast_1d(np.int32(365 * C + np.int32(0.25 * C)))
+    E = np.atleast_1d(np.int32((B - D) / 30.6001))
 
     # Convert to date
     day = np.clip(B - D - np.int64(30.6001 * E) + F, 1, None)


### PR DESCRIPTION
Fixes one test error on Python 2.x for Windows:

```
netcdf4-python version: 1.1.2
HDF5 lib version:       1.8.14
netcdf lib version:     4.3.2
numpy version           1.8.2
...............................E..................................
======================================================================
ERROR: runTest (tst_netcdftime.netcdftimeTestCase)
testing netcdftime
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\Build\netCDF4\netcdf4-python-static-git\test\tst_netcdftime.py", line 51, in runTest
    d2 = self.cdftime_mixed.num2date(t1)
  File "X:\Python27\lib\site-packages\netcdftime\netcdftime.py", line 824, in num2date
    date = DateFromJulianDay(jd, self.calendar)
  File "X:\Python27\lib\site-packages\netcdftime\netcdftime.py", line 290, in DateFromJulianDay
    month[month > 12] = month[month > 12] - 12
IndexError: invalid index to scalar variable.

----------------------------------------------------------------------
Ran 66 tests in 6.188s

FAILED (errors=1)
```
