### PR TITLE
Speedup conversion of array indices to slices

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,7 @@
  ===================
 
  * fix for microsecond calculation in netcdftime (issue #321).
+ * speedup conversion of array indices to slices (issue #325).
 
  version 1.1.3 (tag v1.1.3rel)
  =============================
@@ -17,7 +18,7 @@
 
  * fix for issue 312 (allow slicing with objects that can be cast to ints).
  * indexing netCDF variables with integer sequences and boolean arrays now
-   behave the same way (integer sequences are converted to boolean arrays 
+   behave the same way (integer sequences are converted to boolean arrays
    internally). Addresses issue #300.  Since indexing using integer sequences
    does not behave exactly as before, some client code may break.  For example,
    previously when integer index arrays had the same length, and that length

--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,5 @@
- since version 1.1.3
- ===================
+ version 1.1.4 (not yet released)
+ ===============================
 
  * fix for microsecond calculation in netcdftime (issue #321).
  * speedup conversion of array indices to slices (issue #325).

--- a/netCDF4.c
+++ b/netCDF4.c
@@ -1430,7 +1430,7 @@ static char __pyx_k_view[] = "view";
 static char __pyx_k_vlen[] = "vlen";
 static char __pyx_k_warn[] = "warn";
 static char __pyx_k_zlib[] = "zlib";
-static char __pyx_k_1_1_3[] = "1.1.3";
+static char __pyx_k_1_1_4[] = "1.1.4";
 static char __pyx_k_4_2_1[] = "4.2.1";
 static char __pyx_k_align[] = "align";
 static char __pyx_k_array[] = "array";
@@ -1859,7 +1859,7 @@ static char __pyx_k_master_dataset_s_does_not_have_a_2[] = "master dataset %s do
 static PyObject *__pyx_n_s_;
 static PyObject *__pyx_kp_s_0m;
 static PyObject *__pyx_kp_s_1;
-static PyObject *__pyx_kp_s_1_1_3;
+static PyObject *__pyx_kp_s_1_1_4;
 static PyObject *__pyx_kp_s_4_2_1;
 static PyObject *__pyx_kp_s_4m;
 static PyObject *__pyx_n_s_AttributeError;
@@ -59091,7 +59091,7 @@ static __Pyx_StringTabEntry __pyx_string_tab[] = {
   {&__pyx_n_s_, __pyx_k_, sizeof(__pyx_k_), 0, 0, 1, 1},
   {&__pyx_kp_s_0m, __pyx_k_0m, sizeof(__pyx_k_0m), 0, 0, 1, 0},
   {&__pyx_kp_s_1, __pyx_k_1, sizeof(__pyx_k_1), 0, 0, 1, 0},
-  {&__pyx_kp_s_1_1_3, __pyx_k_1_1_3, sizeof(__pyx_k_1_1_3), 0, 0, 1, 0},
+  {&__pyx_kp_s_1_1_4, __pyx_k_1_1_4, sizeof(__pyx_k_1_1_4), 0, 0, 1, 0},
   {&__pyx_kp_s_4_2_1, __pyx_k_4_2_1, sizeof(__pyx_k_4_2_1), 0, 0, 1, 0},
   {&__pyx_kp_s_4m, __pyx_k_4m, sizeof(__pyx_k_4m), 0, 0, 1, 0},
   {&__pyx_n_s_AttributeError, __pyx_k_AttributeError, sizeof(__pyx_k_AttributeError), 0, 0, 1, 1},
@@ -61670,11 +61670,11 @@ PyMODINIT_FUNC PyInit_netCDF4(void)
   /* "netCDF4.pyx":814
  *     pass
  * 
- * __version__ = "1.1.3"             # <<<<<<<<<<<<<<
+ * __version__ = "1.1.4"             # <<<<<<<<<<<<<<
  * 
  * # Initialize numpy
  */
-  if (PyDict_SetItem(__pyx_d, __pyx_n_s_version, __pyx_kp_s_1_1_3) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 814; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (PyDict_SetItem(__pyx_d, __pyx_n_s_version, __pyx_kp_s_1_1_4) < 0) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 814; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
 
   /* "netCDF4.pyx":817
  * 

--- a/netCDF4.pyx
+++ b/netCDF4.pyx
@@ -811,7 +811,7 @@ except ImportError:
     # python3: zip is already python2's itertools.izip
     pass
 
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 
 # Initialize numpy
 import posixpath

--- a/netCDF4_utils.py
+++ b/netCDF4_utils.py
@@ -203,7 +203,7 @@ def _StartCountStride(elem, shape, dimensions=None, grp=None, datashape=None,\
                 elen = max(ea.max()+1,elen)
             else:
                 if ea.max()+1 > elen:
-                    msg="integer index exceeds dimension size" 
+                    msg="integer index exceeds dimension size"
                     raise IndexError(msg)
             eb = np.zeros(elen,np.bool)
             eb[ea] = True
@@ -244,36 +244,20 @@ Boolean array must have the same shape as the data along this dimension."""
             hasEllipsis = True
         # Replace boolean array with slice object if possible.
         elif ea.dtype.kind == 'b':
-            el = e.tolist()
-            if any(el):
-                start = el.index(True)
-                el.reverse()
-                stop = len(el)-el.index(True)
-                step = False
-                if e[start:stop].all():
-                    step = 1
+            if ea.any():
+                indices = np.flatnonzero(ea)
+                start = indices[0]
+                stop = indices[-1] + 1
+                if len(indices) >= 2:
+                    step = indices[1] - indices[0]
                 else:
-                    n1 = start+1
-                    ee = e[n1]
-                    estart = e[start]
-                    while ee != estart:
-                        n1 = n1 + 1
-                        ee = e[n1]
-                    step = n1-start
-                    # check to make sure e[start:stop:step] are all True,
-                    # and other elements in e[start:stop] are all False.
-                    ii = range(start,stop,step)
-                    for i in range(start,stop):
-                        if i not in ii:
-                            if e[i]: step = False
-                        else:
-                            if not e[i]: step = False
-                if step: # it step False, can't convert to slice.
-                    newElem.append(slice(start,stop,step))
+                    step = None
+                if np.array_equal(indices, np.arange(start, stop, step)):
+                    newElem.append(slice(start, stop, step))
                 else:
-                    newElem.append(e)
+                    newElem.append(ea)
             else:
-                newElem.append(slice(0,0))
+                newElem.append(slice(0, 0))
         else:
             newElem.append(e)
     elem = newElem

--- a/setup.py
+++ b/setup.py
@@ -349,7 +349,7 @@ else:
 
 setup(name = "netCDF4",
   cmdclass = cmdclass,
-  version = "1.1.3",
+  version = "1.1.4",
   long_description = "netCDF version 4 has many features not found in earlier versions of the library, such as hierarchical groups, zlib compression, multiple unlimited dimensions, and new data types.  It is implemented on top of HDF5.  This module implements most of the new features, and can read and write netCDF files compatible with older versions of the library.  The API is modelled after Scientific.IO.NetCDF, and should be familiar to users of that module.\n\nThis project has a `Subversion repository <http://code.google.com/p/netcdf4-python/source>`_ where you may access the most up-to-date source.",
   author            = "Jeff Whitaker",
   author_email      = "jeffrey.s.whitaker@noaa.gov",


### PR DESCRIPTION
This is an alternative PR to #326 that uses vectorized operations instead of removing array to slice conversion.

Fixes #325