### PR TITLE
Fix issue in installation where USE_NCCONFIG is requested but the nc-config is not installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,10 @@ if USE_NCCONFIG is not None:
             ncconfig = os.path.join(netCDF4_dir,'bin/nc-config')
         else: # otherwise, just hope it's in the users PATH.
             ncconfig = 'nc-config'
-    retcode =  subprocess.call([ncconfig,'--libs'],stdout=subprocess.PIPE)
+    try:
+        retcode =  subprocess.call([ncconfig,'--libs'],stdout=subprocess.PIPE)
+    except:
+        retcode = 1
 else:
     retcode = 1
 


### PR DESCRIPTION
This addresses #340.

This just started on some Travis systems because version 1.1.4 introduced a `use_ncconfig = True` in the default `setup.cfg` file that pip was executing.  This caused `setup.py` to look for `nc-config` and try to run it, hoping it was in the `PATH`.  If it *wasn't*, it threw an `OSError` rather than simply returning a non-zero exit code.

On Windows, this raised a `WindowsError`, whereas on *nix it raised a `OSError`.  Since I'm not sure if `WindowsError` subclasses `OSError` and I don't use Windows, I just threw in a bare except (I don't think there's a real risk of that masking an error in this case).

A workaround is to make sure that `nc-config` *is* available when you build `netCDF4-1.1.4` (on Travis, that means installing `netcdf-bin` in addition to `libnetcdf-dev`).