### PR TITLE
gitattributes to limit export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+examples/data export-ignore
+.gitattributes export-ignore
+.git export-ignore
+.gitignore export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@ examples/data export-ignore
 .gitattributes export-ignore
 .git export-ignore
 .gitignore export-ignore
+.travis.yml export-ignore


### PR DESCRIPTION
Adding attributes to limit the export of several _huge_ files.

Also the hidden files are strictly not needed.