### PR TITLE
Remove code that has no effect

### DIFF
--- a/utils.pyx
+++ b/utils.pyx
@@ -453,7 +453,6 @@ Default is an empty list.
                     #if not vInst.dimensions[0] != aggDimName:
 
                     masterDims, masterShape, masterType = masterRecVar[v][:3]
-                    extDims, extShape, extType = varInfo[v][:3]
                     extDims = varInfo[v].dimensions
                     extShape = varInfo[v].shape
                     extType = varInfo[v].dtype


### PR DESCRIPTION
Remove this line because the next three lines replace its action.
(Actually in my case that line causes python to error out, and I can't see any justification for keeping it.)
