### PR TITLE
Don't run tests that require network connectivity if NO_NET is set.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 env:
     global:
         - DEPENDS="numpy cython"
+        - NO_NET=1
 python:
   - "2.7"
   - "3.3"

--- a/test/run_all.py
+++ b/test/run_all.py
@@ -19,7 +19,7 @@ if __netcdf4libversion__ < '4.2.1':
     sys.stdout.write('not running tst_diskless.py ...\n')
 
 # Don't run tests that require network connectivity
-if os.environ['NO_NET']:
+if os.getenv('NO_NET'):
     test_files.remove('tst_dap.py');
     sys.stdout.write('not running tst_dap.py ...\n')
 

--- a/test/run_all.py
+++ b/test/run_all.py
@@ -18,6 +18,11 @@ if __netcdf4libversion__ < '4.2.1':
     test_files.remove('tst_diskless.py')
     sys.stdout.write('not running tst_diskless.py ...\n')
 
+# Don't run tests that require network connectivity
+if os.environ['NO_NET']:
+    test_files.remove('tst_dap.py');
+    sys.stdout.write('not running tst_dap.py ...\n')
+
 # Build the test suite from the tests found in the test files.
 testsuite = unittest.TestSuite()
 for f in test_files:


### PR DESCRIPTION
This excludes tst_dap.py from being run to allow running all remaining tests in build chroots without network.