### PR TITLE
Preserve seconds during back and forth conversion of Julian dates

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -9,6 +9,8 @@
    (same as numpy does for len() on a scalar array).
  * translate docstrings from epydoc markup to markdown, so
    pdoc can be used (epydoc is dead).
+ * add small offset in conversion to Julian date for numerical
+   stability. Remove the offset in back conversion only from microseconds.
 
  version 1.1.8 (tag v1.1.8rel)
  =============================

--- a/netcdftime/netcdftime.py
+++ b/netcdftime/netcdftime.py
@@ -33,8 +33,6 @@ ISO8601_REGEX = re.compile(r"(?P<year>[0-9]{1,4})(-(?P<month>[0-9]{1,2})(-(?P<da
 TIMEZONE_REGEX = re.compile(
     "(?P<prefix>[+-])(?P<hours>[0-9]{1,2}):(?P<minutes>[0-9]{1,2})")
 
-domc = True
-
 def JulianDayFromDate(date, calendar='standard'):
     """
 
@@ -120,11 +118,11 @@ def JulianDayFromDate(date, calendar='standard'):
     # adjust for Julian calendar if necessary
     jd = jd + B
 
-    if domc:
-        # MC - Add a small offset (proportional to Julian date) for correct re-conversion.
-        eps = 2.22e-016 # ~ Fortran epsilon(1.0) in double precision
-        eps = np.maximum(eps*jd, eps)
-        jd += eps
+    # MC - Add a small offset (proportional to Julian date) for correct re-conversion.
+    # This is about 45 microseconds in 2000 for Julian date starting -4712.
+    eps = np.finfo(float).eps
+    eps = np.maximum(eps*jd, eps)
+    jd += eps
 
     if isscalar:
         return jd[0]
@@ -254,11 +252,7 @@ def DateFromJulianDay(JD, calendar='standard'):
     # get the day (Z) and the fraction of the day (F)
     # add 0.000005 which is 452 ms in case of jd being after
     # second 23:59:59 of a day we want to round to the next day see issue #75
-    if domc:
-        # MC - epsilon was already done in JulianDayFromDate
-        Z = np.atleast_1d(np.int32(np.round(julian)))
-    else:
-        Z = np.atleast_1d(np.int32(np.round(julian + 0.00005)))
+    Z = np.atleast_1d(np.int32(np.round(julian)))
     F = np.atleast_1d(julian + 0.5 - Z).astype(np.float64)
     if calendar in ['standard', 'gregorian']:
         # MC
@@ -325,28 +319,18 @@ def DateFromJulianDay(JD, calendar='standard'):
     inc_idx = np.where((leap == 1) & (month > 2))[0]
     dayofyr[inc_idx] = dayofyr[inc_idx] + leap[inc_idx]
 
-    if domc:
-        # MC - Substract the offset from JulianDayFromDate from the microseconds
-        eps = 2.22e-016 # ~ Fortran epsilon(1.0) in double precision
-        eps = np.maximum(eps*julian, eps)
-        hour = np.clip((F * 24.).astype(np.int64), 0, 23)
-        F -= hour / 24.
-        minute = np.clip((F * 1440.).astype(np.int64), 0, 59)
-        # overestimation
-        second = np.clip((F - minute / 1440.) * 86400., 0, None)
-        # this would be an underestimation, which is undesireable for 0 microseconds
-        # second = np.clip((F - minute / 1440. - eps) * 86400., 0, None)
-        microsecond = (second % 1)*1.e6
-        microsecond = np.clip(microsecond - eps*86400.*1e6, 0, 999999)
-    else:
-        eps = np.clip(
-            (1e-12 * np.abs(Z)).astype(np.float64), np.float64(1e-12), None)
-        hour = np.clip((F * 24. + eps).astype(np.int64), 0, 23)
-        F -= hour / 24.
-        minute = np.clip((F * 1440. + eps).astype(np.int64), 0, 59)
-        second = np.clip((F - minute / 1440.) * 86400., 0, None)
-        # microseconds may not be accurate.
-        microsecond = (second % 1)*1.e6
+    # MC - Substract the offset from JulianDayFromDate from the microseconds
+    eps = np.finfo(float).eps
+    eps = np.maximum(eps*julian, eps)
+    hour = np.clip((F * 24.).astype(np.int64), 0, 23)
+    F   -= hour / 24.
+    minute = np.clip((F * 1440.).astype(np.int64), 0, 59)
+    # overestimation due to added offset in JulianDayFromDate
+    second = np.clip((F - minute / 1440.) * 86400., 0, None)
+    # this would underestimate, which is undesireable for 0 microseconds, which is the default
+    # second = np.clip((F - minute / 1440. - eps) * 86400., 0, None)
+    microsecond = (second % 1)*1.e6
+    microsecond = np.clip(microsecond - eps*86400.*1e6, 0, 999999)
 
     # convert year, month, day, hour, minute, second to int32
     year = year.astype(np.int32)

--- a/test/tst_netcdftime.py
+++ b/test/tst_netcdftime.py
@@ -208,7 +208,7 @@ class netcdftimeTestCase(unittest.TestCase):
         assert_equal(numpy.around(t), 3600)
         # test fix for issue 75 (seconds hit 60 at end of month,
         # day goes out of range).
-        t = 733498.999999
+        t = 733498.9999999999 #MC < 1 microsecond wrong - old 733498.999999 is 8640 microseconds off the real 733499
         d = num2date(t, units='days since 0001-01-01 00:00:00')
         dateformat =  '%Y-%m-%d %H:%M:%S'
         assert_equal(d.strftime(dateformat), '2009-04-01 00:00:00')


### PR DESCRIPTION
Dear Jeff,

I am using the routines date2num and num2date and realised that they do not give the same results when I convert back and forth:
In [1]: import netCDF4 as nt
In [2]: jd0 = 1721424.
In [3]: jd = nt.date2num(nt.datetime(1810, 4, 24, 16, 15, 10), 'days since 0001-01-01 12:00:00', calendar='gregorian')+jd0
In [4]: nt.num2date(jd-jd0, 'days since 0001-01-01 12:00:00', calendar='gregorian')
Out[4]: datetime.datetime(1810, 4, 24, 16, 15, 9, 999999)

jd0 is the Julian Day of 0001-01-01 12:00:00.
As you can see, I get only 9 seconds back instead of second 10.

In my Fortran code, I normally add a little epsilon so that the back conversion works.
When I do this:
In [1]: import netCDF4 as nt
In [2]: jd0 = 1721424.
In [3]: jd = nt.date2num(nt.datetime(1810, 4, 24, 16, 15, 10, 5), 'days since 0001-01-01 12:00:00', calendar='gregorian')+jd0 
In [4]: nt.num2date(jd-jd0, 'days since 0001-01-01 12:00:00:00', calendar='gregorian')
Out[4]: datetime.datetime(1810, 4, 24, 16, 15, 10)

As you can see, it works well for everything but the microseconds. This is because 1 microsecond is
In [5]: 1./1e6/86400.
Out[5]: 1.1574074074074074e-11
whereas the correction is ca.
In [7]: 2382262.1771990741*2.22E-016
Out[7]: 5.288622033381944e-10
that means around 45 microseconds.

Until now, I do
  1. Add the epsilon (above) in JulianDayFromDate.
  2. Do not add 0.00005 to Z in DateFromJulianDay als set eps = 0.
  3. Substract the epsilon only from the microseconds not on anything before.

With this I am always less then 30 microseconds high. With your formulation, we are also less than 30 microseconds off but with a tendency for lower numbers. This is undesireable because 0 microseconds is the default (and what most people would want) and your code gives often the second just below the real second.

My code is always a bit high so that the seconds flips erronously at about 999980 microseconds.

If one wants more precision, one has to go to 128-bit. One could borrow from the astropy library, which does exactly this and gets nanosecond resolution.

Please find my changes. Until now there is a global switch domc = True that switches between old (False) and new (True) formulations.

Kind regards
Matthias
