### PR TITLE
Travis container builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,45 @@
 language: python
+
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - libhdf5-serial-dev
+      - netcdf-bin
+      - libnetcdf-dev
+
 env:
-    global:
-        - DEPENDS="numpy cython"
-        - NO_NET=1
+  global:
+    - DEPENDS="numpy cython"
+    - NO_NET=1
+
 python:
   - "2.7"
   - "3.3"
   - "3.4"
+
 matrix:
   include:
-    # Absolute minimum dependencies
+    # Absolute minimum dependencies.
     - python: 2.7
       env:
         - DEPENDS="numpy==1.7.0 cython==0.19"
-    # test without Cython installed
+    # Test without Cython installed.
     - python: 2.7
       env:
         - DEPENDS="numpy"
+
 notifications:
   email: false
+
 before_install:
-  - sudo apt-get install libhdf5-serial-dev netcdf-bin libnetcdf-dev
   - pip install $DEPENDS
+
 install:
   - python setup.py build
   - python setup.py install
+
 script:
   - cd test
   - python run_all.py


### PR DESCRIPTION
By using `sudo: false` Travis-CI build will use the new container builds.  The main advantage is a faster start.  (See more at http://docs.travis-ci.com/user/workers/container-based-infrastructure/.)