### PR TITLE
BUG: fix test teardown on windows.

### DIFF
--- a/test/tst_slicing.py
+++ b/test/tst_slicing.py
@@ -192,6 +192,7 @@ class VariablesTestCase(unittest.TestCase):
         shape = (9,)
         data = v[keys]
         assert_equal(data.shape, shape)
+        f.close()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes the test suite on windows: one file was not close, causing the teardown to fail (you cannot remove file which are opened on windows).