### PR TITLE
allow non-contiguous dates for Gregorian calendar

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
  since version 1.2.1
  ===================
  * fix bug in nc3tonc4 with --unpackshort=1 (issue 474).
+ * dates do not have to be contiguous, i.e. can be before and after the missing dates in Gregorian calendar
 
  version 1.2.1 (tag v1.2.1rel)
  =============================

--- a/netcdftime/netcdftime.py
+++ b/netcdftime/netcdftime.py
@@ -86,7 +86,9 @@ def JulianDayFromDate(date, calendar='standard'):
     month[month_lt_3] = month[month_lt_3] + 12
     year[month_lt_3] = year[month_lt_3] - 1
 
-    A = np.int64(year / 100)
+    # MC - assure array
+    # A = np.int64(year / 100)
+    A = (year / 100).astype(np.int64)
 
     # MC
     # jd = int(365.25 * (year + 4716)) + int(30.6001 * (month + 1)) + \
@@ -98,15 +100,25 @@ def JulianDayFromDate(date, calendar='standard'):
     # the Julian to Gregorian Calendar
     # here assumed to have occurred the day after 1582 October 4
     if calendar in ['standard', 'gregorian']:
-        if np.min(jd) >= 2299170.5:
-            # 1582 October 15 (Gregorian Calendar)
-            B = 2 - A + np.int32(A / 4)
-        elif np.max(jd) < 2299160.5:
-            # 1582 October 5 (Julian Calendar)
-            B = np.zeros(len(jd))
-        else:
+        # MC - do not have to be contiguous dates
+        # if np.min(jd) >= 2299170.5:
+        #     # 1582 October 15 (Gregorian Calendar)
+        #     B = 2 - A + np.int32(A / 4)
+        # elif np.max(jd) < 2299160.5:
+        #     # 1582 October 5 (Julian Calendar)
+        #     B = np.zeros(len(jd))
+        # else:
+        #     print(date, calendar, jd)
+        #     raise ValueError(
+        #         'impossible date (falls in gap between end of Julian calendar and beginning of Gregorian calendar')
+        if np.any((jd >= 2299160.5) & (jd < 2299170.5)): # missing days in Gregorian calendar
+            print(date, calendar, jd)
             raise ValueError(
                 'impossible date (falls in gap between end of Julian calendar and beginning of Gregorian calendar')
+        B = np.zeros(len(jd))             # 1582 October 5 (Julian Calendar)
+        ii = np.where(jd >= 2299170.5)[0] # 1582 October 15 (Gregorian Calendar)
+        if ii.size>0:
+            B[ii] = 2 - A[ii] + np.int32(A[ii] / 4)
     elif calendar == 'proleptic_gregorian':
         B = 2 - A + np.int32(A / 4)
     elif calendar == 'julian':

--- a/netcdftime/netcdftime.py
+++ b/netcdftime/netcdftime.py
@@ -112,7 +112,6 @@ def JulianDayFromDate(date, calendar='standard'):
         #     raise ValueError(
         #         'impossible date (falls in gap between end of Julian calendar and beginning of Gregorian calendar')
         if np.any((jd >= 2299160.5) & (jd < 2299170.5)): # missing days in Gregorian calendar
-            print(date, calendar, jd)
             raise ValueError(
                 'impossible date (falls in gap between end of Julian calendar and beginning of Gregorian calendar')
         B = np.zeros(len(jd))             # 1582 October 5 (Julian Calendar)

--- a/test/tst_netcdftime.py
+++ b/test/tst_netcdftime.py
@@ -432,6 +432,24 @@ class netcdftimeTestCase(unittest.TestCase):
         d = num2date(0, units, calendar='360_day')
         self.assertEqual(d, datetimex(0,1,1))
 
+        # list around missing dates in Gregorian calendar
+        # scalar
+        units = 'days since 0001-01-01 12:00:00'
+        t1 = date2num(datetime(1582, 10, 4), units, calendar='gregorian')
+        t2 = date2num(datetime(1582, 10, 15), units, calendar='gregorian')
+        self.assertEqual(t1+1, t2)
+        # list
+        t1, t2 = date2num([datetime(1582, 10, 4), datetime(1582, 10, 15)], units, calendar='gregorian')
+        self.assertEqual(t1+1, t2)
+        t1, t2 = date2num([datetime(1582, 10, 4), datetime(1582, 10, 15)], units, calendar='standard')
+        self.assertEqual(t1+1, t2)
+        # this should fail: days missing in Gregorian calendar
+        try:
+            t1, t2, t3 = date2num([datetime(1582, 10, 4), datetime(1582, 10, 10), datetime(1582, 10, 15)], units, calendar='standard')
+        except ValueError:
+            pass
+
+
 class TestDate2index(unittest.TestCase):
 
     class TestTime:


### PR DESCRIPTION
Allow non-contiguous dates for Gregorian calendar, i.e. there can be dates before and after the missing days in 1582.

Before it was checked if min(dates) and max(dates) are below or above the missing five days in 1582. Now each julian date is checked that it is not in-between these five days.

2 checks in tst_netcdftime.py fail and 78 checks fail in the test directory with run_all.py. But these these tests all fail already in the master directory https://github.com/Unidata/netcdf4-python/

Regards
Matthias


