### PR TITLE
Adjust setup.py to find netcdf and HDF5 on debian 8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -248,7 +248,20 @@ if not retcode:
     lib_dirs = [str(l[2:].decode()) for l in dep.split() if l[0:2].decode() == '-L' ]
     dep=subprocess.Popen([ncconfig,'--cflags'],stdout=subprocess.PIPE).communicate()[0]
     inc_dirs = [str(i[2:].decode()) for i in dep.split() if i[0:2].decode() == '-I']
-# if nc-config didn't work (it won't on windows), fall back on brute force method
+elif subprocess.call(['pkg-config','--libs', 'hdf5'],stdout=subprocess.PIPE) == 0:
+    sys.stdout.write('using pkg-config ...\n')
+    dep=subprocess.Popen(['pkg-config','--libs','netcdf'],stdout=subprocess.PIPE).communicate()[0]
+    libs = [str(l[2:].decode()) for l in dep.split() if l[0:2].decode() == '-l' ]
+    lib_dirs = [str(l[2:].decode()) for l in dep.split() if l[0:2].decode() == '-L' ]
+    dep=subprocess.Popen(['pkg-config','--cflags', 'hdf5'],stdout=subprocess.PIPE).communicate()[0]
+    inc_dirs = [str(i[2:].decode()) for i in dep.split() if i[0:2].decode() == '-I']
+    dep=subprocess.Popen(['pkg-config','--libs','hdf5'],stdout=subprocess.PIPE).communicate()[0]
+    libs.extend([str(l[2:].decode()) for l in dep.split() if l[0:2].decode() == '-l' ])
+    lib_dirs.extend([str(l[2:].decode()) for l in dep.split() if l[0:2].decode() == '-L' ])
+    dep=subprocess.Popen(['pkg-config','--cflags', 'hdf5'],stdout=subprocess.PIPE).communicate()[0]
+    inc_dirs.extend([str(i[2:].decode()) for i in dep.split() if i[0:2].decode() == '-I'])
+
+# if nc-config and pkg-config both didn't work (it won't on windows), fall back on brute force method
 else:
     dirstosearch =  [os.path.expanduser('~'),'/usr/local','/sw','/opt','/opt/local', '/usr']
 


### PR DESCRIPTION
Use `pkg-config` to find appropriate compiler flags for dependencies.

Note that has been tested for pip and python3.4.2 on a Debian8 vm using:
```shell
$ pip install -vvv git+ssh://github.com/bluesquall/netcdf4-python.git@debian-pkg-config#egg=netCDF4
```
that is, without needing to manually set `USE_SETUPCFG=0`, `HDF5_INCDIR`, and `HDF5_LIBDIR` as in issues #438 and #430.

On this machine, the `netcdf-bin` package is *not* installed, so `nc-config` does not exist. On a related not, if `nc-config` were installed, it would return different values for the libraries and include directories than what `pkg-config` returns. This is probably a bug in `nc-config` upstream for Debian and variants, as noted in [this comment](https://github.com/Unidata/netcdf4-python/issues/438#issuecomment-123110407). I don't have time to dig into that deeper right now, but it's on my backburner list.