### PR TITLE
AppVeyor Rolling builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,16 @@ platform:
     - x64
 
 install:
+    # If there is a newer build queued for the same PR, cancel this one.
+    # The AppVeyor 'rollout builds' option is supposed to serve the same
+    # purpose but it is problematic because it tends to cancel builds pushed
+    # directly to master instead of just PR builds (or the converse).
+    # credits: JuliaLang developers.
+    - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+         https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+         Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+           throw "There are newer queued builds for this pull request, failing early." }
+
     # Set the CONDA_NPY, although it has no impact on the actual build.
     # We need this because of a test within conda-build.
     - cmd: set CONDA_NPY=19


### PR DESCRIPTION
AppVeyor puts all PR updates in a test queue that can get very big (and slow) with just a few commit.
This PR cancels any previous test if a new commit exist on the same PR.