### PR TITLE
BF: allow tests to pass without ncdump

### DIFF
--- a/test/tst_atts.py
+++ b/test/tst_atts.py
@@ -139,17 +139,23 @@ class VariablesTestCase(unittest.TestCase):
         assert v.getncattr('foo') == 1
         assert v.getncattr('bar') == 2
         # check type of attributes using ncdump (issue #529)
-        dep=subprocess.Popen(['ncdump','-h',FILE_NAME],stdout=subprocess.PIPE).communicate()[0]
-        try: # python 2
-            ncdump_output = dep.split('\n')
-        except TypeError: # python 3
-            ncdump_output = str(dep,encoding='utf-8').split('\n')
-        for line in ncdump_output:
-            line = line.strip('\t\n\r')
-            if "stringatt" in line: assert line.startswith('string')
-            if "charatt" in line: assert line.startswith(':')
-            if "cafe" in line: assert line.startswith('string')
-            if "batt" in line: assert line.startswith(':')
+        try:  # ncdump may not be on the system PATH
+            nc_proc = subprocess.Popen(
+                ['ncdump', '-h', FILE_NAME], stdout=subprocess.PIPE)
+        except OSError:
+            pass
+        else:  # We do have ncdump output
+            dep = nc_proc.communicate()[0]
+            try: # python 2
+                ncdump_output = dep.split('\n')
+            except TypeError: # python 3
+                ncdump_output = str(dep,encoding='utf-8').split('\n')
+            for line in ncdump_output:
+                line = line.strip('\t\n\r')
+                if "stringatt" in line: assert line.startswith('string')
+                if "charatt" in line: assert line.startswith(':')
+                if "cafe" in line: assert line.startswith('string')
+                if "batt" in line: assert line.startswith(':')
         # check attributes in subgroup.
         # global attributes.
         for key,val in ATTDICT.items():

--- a/test/tst_atts.py
+++ b/test/tst_atts.py
@@ -4,6 +4,8 @@ import sys
 import unittest
 import os
 import tempfile
+import warnings
+
 import numpy as NP
 from numpy.random.mtrand import uniform
 import netCDF4
@@ -143,6 +145,8 @@ class VariablesTestCase(unittest.TestCase):
             nc_proc = subprocess.Popen(
                 ['ncdump', '-h', FILE_NAME], stdout=subprocess.PIPE)
         except OSError:
+            warnings.warn('"ncdump" not on system path; cannot test '
+                          'read of some attributes')
             pass
         else:  # We do have ncdump output
             dep = nc_proc.communicate()[0]


### PR DESCRIPTION
ncdump may not be on the system path when the tests run.

Allow tests to pass when ncdump not on path.

Fixes #556.