### PR TITLE
Correct Documentation Parenthesis Position

### DIFF
--- a/docs/netCDF4/index.html
+++ b/docs/netCDF4/index.html
@@ -1879,8 +1879,8 @@ sacrificed for the sake of disk space.</p>
 
 <p>and see how much smaller the resulting files are.</p>
 <h2><div id='section10'>10) Beyond homogeneous arrays of a fixed type - compound data types.</h2>
-<p>Compound data types map directly to numpy structured (a.k.a 'record')
-arrays.  Structured arrays are akin to C structs, or derived types
+<p>Compound data types map directly to numpy structured (a.k.a 'record'
+arrays).  Structured arrays are akin to C structs, or derived types
 in Fortran. They allow for the construction of table-like structures
 composed of combinations of other data types, including other
 compound types. Compound types might be useful for representing multiple

--- a/docs/netCDF4/index.html
+++ b/docs/netCDF4/index.html
@@ -1879,8 +1879,8 @@ sacrificed for the sake of disk space.</p>
 
 <p>and see how much smaller the resulting files are.</p>
 <h2><div id='section10'>10) Beyond homogeneous arrays of a fixed type - compound data types.</h2>
-<p>Compound data types map directly to numpy structured (a.k.a 'record'
-arrays).  Structured arrays are akin to C structs, or derived types
+<p>Compound data types map directly to numpy structured (a.k.a 'record')
+arrays.  Structured arrays are akin to C structs, or derived types
 in Fortran. They allow for the construction of table-like structures
 composed of combinations of other data types, including other
 compound types. Compound types might be useful for representing multiple

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -664,8 +664,8 @@ and see how much smaller the resulting files are.
 
 ## <div id='section10'>10) Beyond homogeneous arrays of a fixed type - compound data types.
 
-Compound data types map directly to numpy structured (a.k.a 'record'
-arrays).  Structured arrays are akin to C structs, or derived types
+Compound data types map directly to numpy structured (a.k.a 'record')
+arrays.  Structured arrays are akin to C structs, or derived types
 in Fortran. They allow for the construction of table-like structures
 composed of combinations of other data types, including other
 compound types. Compound types might be useful for representing multiple


### PR DESCRIPTION
I think the position of a parenthesis in the documentation is wrong:
> Compound data types map directly to numpy structured (a.k.a 'record' arrays).

If the part in parentheses were removed, the sentence would be incomplete, i.e.
> Compound data types map directly to numpy structured.

This pull request moves the position of the parenthesis to correct the problem:
> Compound data types map directly to numpy structured (a.k.a 'record') arrays.