### PR TITLE
fixed docstring for keepweakref parameter

### DIFF
--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -1679,7 +1679,7 @@ references to the parent Dataset or Group.
                  diskless=False, persist=False, keepweakref=False, **kwargs):
         """
         **`__init__(self, filename, mode="r", clobber=True, diskless=False,
-        persist=False, weakref=False, format='NETCDF4')`**
+        persist=False, keepweakref=False, format='NETCDF4')`**
 
         `netCDF4.Dataset` constructor.
 
@@ -1734,11 +1734,12 @@ references to the parent Dataset or Group.
         reference to child Dimension and Variable instances, creates circular references.
         Circular references complicate garbage collection, which may mean increased
         memory usage for programs that create may Dataset instances with lots of
-        Variables.  Setting `keepweakref=True` allows Dataset instances to be
-        garbage collected as soon as they go out of scope, potential reducing memory
-        usage.  However, in most cases this is not desirable, since the associated
-        Variable instances may still be needed, but are rendered unusable when the
-        parent Dataset instance is garbage collected.
+        Variables. IT also will result in the Dataset object never being deleted, which
+        means it may keep open files alive as well. Setting `keepweakref=True` allows
+        Dataset instances to be garbage collected as soon as they go out of scope, potentially
+        reducing memory usage and open file handles.  However, in many cases this is not
+        desirable, since the associated Variable instances may still be needed, but are
+        rendered unusable when the parent Dataset instance is garbage collected.
         """
         cdef int grpid, ierr, numgrps, numdims, numvars
         cdef char *path

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -1734,7 +1734,7 @@ references to the parent Dataset or Group.
         reference to child Dimension and Variable instances, creates circular references.
         Circular references complicate garbage collection, which may mean increased
         memory usage for programs that create may Dataset instances with lots of
-        Variables. IT also will result in the Dataset object never being deleted, which
+        Variables. It also will result in the Dataset object never being deleted, which
         means it may keep open files alive as well. Setting `keepweakref=True` allows
         Dataset instances to be garbage collected as soon as they go out of scope, potentially
         reducing memory usage and open file handles.  However, in many cases this is not


### PR DESCRIPTION
The docstring had `weakref=False`, rather than `keepweakref=False`, which means a user could not get the functionality desired.

I also added a bit more to the docs about why one would want to use weak references.

