### PR TITLE
Fully support masked time array operations

### DIFF
--- a/netcdftime/netcdftime.py
+++ b/netcdftime/netcdftime.py
@@ -870,6 +870,8 @@ units to datetime objects.
                 date = _DateFrom360Day(jd)
         if isscalar:
             return date
+        elif ismasked:
+            return numpy.reshape(numpy.ma.array(date, mask=mask), shape)
         else:
             return numpy.reshape(numpy.array(date), shape)
 

--- a/test/tst_netcdftime.py
+++ b/test/tst_netcdftime.py
@@ -463,6 +463,16 @@ class netcdftimeTestCase(unittest.TestCase):
         except ValueError:
             pass
 
+        # Test masked array support
+        import numpy as np
+        unit_a = 'days since 1990-01-01 00:00:00'
+        unit_b = 'days since 1989-01-01 00:00:00'
+        dt = num2date(np.ma.array(range(5), mask=[False, True, False, True, False]), units=unit_a)
+        new_masked_array = date2num(dt, unit_b)
+        assert hasattr(new_masked_array, 'mask')
+        wanted = np.ma.array([0, None, 2, None, 4], mask=[False, True, False, True, False]) + 365
+        np.testing.assert_array_almost_equal(new_masked_array, wanted)
+
 
 class TestDate2index(unittest.TestCase):
 


### PR DESCRIPTION
It would be great to support a workflow like:

```
>>> dt = unit_a.num2date(masked_time_array)
>>> new_masked_array= unit_b.date2num(dt)
```

So far I've made num2date output a masked array if that's what it's given, but I still need date2num to deal with masked array inputs.

Let me know if this is something you would be interested in and I'll finish it up.