### PR TITLE
360_day and 365_day calendars: support negative Julian days. See #584.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,8 @@
  * Use valid_min/valid_max/valid_range attributes when defining mask
    (issue #576).  Values outside the valid range are considered to
    be missing when defining the mask.
+ * Fix for issue #584 (add support for dates before -4712-1-1 in 360_day
+   and 365_day calendars to netcdftime.utime).
 
  version 1.2.4 (tag v1.2.4rel)
 ==============================

--- a/netcdftime/netcdftime.py
+++ b/netcdftime/netcdftime.py
@@ -393,7 +393,7 @@ days. Julian Day is a fractional day with a resolution of approximately 0.1 seco
     # based on redate.py by David Finlayson.
 
     if JD < 0:
-        year_offset = -int(JD) / 365 + 1
+        year_offset = int(-JD) // 365 + 1
         JD += year_offset * 365
     else:
         year_offset = 0
@@ -508,7 +508,7 @@ Julian Day is a fractional day with a resolution of approximately 0.1 seconds.
     """
 
     if JD < 0:
-        year_offset = -int(JD) / 360 + 1
+        year_offset = int(-JD) // 360 + 1
         JD += year_offset * 360
     else:
         year_offset = 0

--- a/netcdftime/netcdftime.py
+++ b/netcdftime/netcdftime.py
@@ -393,7 +393,10 @@ days. Julian Day is a fractional day with a resolution of approximately 0.1 seco
     # based on redate.py by David Finlayson.
 
     if JD < 0:
-        raise ValueError('Julian Day must be positive')
+        year_offset = -int(JD) / 365 + 1
+        JD += year_offset * 365
+    else:
+        year_offset = 0
 
     dayofwk = int(math.fmod(int(JD + 1.5), 7))
     (F, Z) = math.modf(JD + 0.5)
@@ -428,7 +431,17 @@ days. Julian Day is a fractional day with a resolution of approximately 0.1 seco
     (sfrac, seconds) = math.modf(mfrac * 60.0)
     microseconds = sfrac*1.e6
 
-    return datetime(year, month, int(days), int(hours), int(minutes),
+    if year_offset > 0:
+        # correct dayofwk
+
+        # 365 mod 7 = 1, so the day of the week changes by one day for
+        # every year in year_offset
+        dayofwk -= int(math.fmod(year_offset, 7))
+
+        if dayofwk < 0:
+            dayofwk += 7
+
+    return datetime(year - year_offset, month, int(days), int(hours), int(minutes),
             int(seconds), int(microseconds),dayofwk, dayofyr)
 
 
@@ -495,7 +508,10 @@ Julian Day is a fractional day with a resolution of approximately 0.1 seconds.
     """
 
     if JD < 0:
-        raise ValueError('Julian Day must be positive')
+        year_offset = -int(JD) / 360 + 1
+        JD += year_offset * 360
+    else:
+        year_offset = 0
 
     #jd = int(360. * (year + 4716)) + int(30. * (month - 1)) + day
     (F, Z) = math.modf(JD)
@@ -511,7 +527,7 @@ Julian Day is a fractional day with a resolution of approximately 0.1 seconds.
     (sfrac, seconds) = math.modf(mfrac * 60.0)
     microseconds = sfrac*1.e6
 
-    return datetime(year, month, int(days), int(hours), int(minutes),
+    return datetime(year - year_offset, month, int(days), int(hours), int(minutes),
             int(seconds), int(microseconds), -1, dayofyr)
 
 

--- a/test/tst_netcdftime.py
+++ b/test/tst_netcdftime.py
@@ -687,7 +687,7 @@ class issue584TestCase(unittest.TestCase):
         julian_day = converter.date2num(datetimex(-4712, 1, 2, 12))
 
         old_date = converter.num2date(julian_day)
-        for delta_year in xrange(1, 101): # 100 years cover several 7-year cycles
+        for delta_year in range(1, 101): # 100 years cover several 7-year cycles
             date = converter.num2date(julian_day - delta_year * 365)
 
             # test that the day of the week changes by one every year (except


### PR DESCRIPTION
In 360-day and 365-day calendars all years have the same length, so it is easy to shift the input by an integer number of years without affecting the date within the year. We can then use an algorithm that requires non-negative Julian days and later shift the year back to its original value.

The day of the week requires a correction: in the 365-day calendar every year of the "shift" changes the day of the week number by 1 (365 mod 7 = 1). The old code for the 360-day calendar does not compute the day of the week, so no correction is applied.