### PR TITLE
Initialize members of vldata to make sure that nc_free_vlens() succeeds. See #527.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -24,6 +24,7 @@
  * Make sure negative years work in utime.num2date (issue #596).
  * raise NotImplementedError when trying to pickle Dataset, Variable,
    CompoundType, VLType, EnumType and MFDataset (issue #602).
+ * Fix for issue #527: initialize vldata[i].p in Variable._get(...).
 
  version 1.2.4 (tag v1.2.4rel)
 ==============================

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -4498,6 +4498,9 @@ The default value of `mask` is `True`
                 # regular vlen
                 # allocate struct array to hold vlen data.
                 vldata = <nc_vlen_t *>malloc(totelem*sizeof(nc_vlen_t))
+                for i in range(totelem):
+                    vldata[i].len = 0
+                    vldata[i].p = <void*>0
                 # strides all 1 or scalar variable, use get_vara (faster)
                 if sum(stride) == ndims or ndims == 0:
                     with nogil:

--- a/test/tst_vlen.py
+++ b/test/tst_vlen.py
@@ -135,6 +135,19 @@ class TestObjectArrayIndexing(unittest.TestCase):
 
 class VlenAppendTestCase(unittest.TestCase):
     def setUp(self):
+
+        import netCDF4
+        if netCDF4.__netcdf4libversion__ < "4.4.1":
+            self.skip = True
+            try:
+                self.skipTest("This test requires NetCDF 4.4.1 or later.")
+            except AttributeError:
+                # workaround for Python 2.6 (skipTest(reason) is new
+                # in Python 2.7)
+                pass
+        else:
+            self.skip = False
+
         self.file = FILE_NAME
         f = Dataset(self.file, 'w')
         vlen_type = f.createVLType(np.float64, 'vltest')
@@ -149,6 +162,10 @@ class VlenAppendTestCase(unittest.TestCase):
 
     def runTest(self):
         """testing appending to vlen variables (issue #527)."""
+        # workaround for Python 2.6
+        if self.skip:
+            return
+
         f = Dataset(self.file, 'a')
         w = f.variables["vl2"]
         v = f.variables["vl"]

--- a/test/tst_vlen.py
+++ b/test/tst_vlen.py
@@ -133,5 +133,31 @@ class TestObjectArrayIndexing(unittest.TestCase):
         assert fancy_indexed[2] == 'abcdef'
         f.close()
 
+class VlenAppendTestCase(unittest.TestCase):
+    def setUp(self):
+        self.file = FILE_NAME
+        f = Dataset(self.file, 'w')
+        vlen_type = f.createVLType(np.float64, 'vltest')
+        f.createDimension('x', None)
+        v = f.createVariable('vl', vlen_type, 'x')
+        w = f.createVariable('vl2', np.float64, 'x')
+        f.close()
+
+    def tearDown(self):
+        # Remove the temporary files
+        os.remove(self.file)
+
+    def runTest(self):
+        """testing appending to vlen variables (issue #527)."""
+        f = Dataset(self.file, 'a')
+        w = f.variables["vl2"]
+        v = f.variables["vl"]
+        w[0:3] = np.arange(3, dtype=np.float64)
+        v[0]                    # sometimes crashes
+        v[0].tolist()           # sometimes crashes
+        v[0].size               # BOOM!
+        f.close()
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Note that `free(NULL)` is a no-op.