### PR TITLE
fixes #686 Encode filename with sys.getfilesystemencoding()

### DIFF
--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -1795,7 +1795,7 @@ references to the parent Dataset or Group.
         if diskless and __netcdf4libversion__ < '4.2.1':
             #diskless = False # don't raise error, instead silently ignore
             raise ValueError('diskless mode requires netcdf lib >= 4.2.1, you have %s' % __netcdf4libversion__)
-        if sys.platform == 'win32:
+        if sys.platform == 'win32':
             bytestr = _strencode(str_filename, encoding='mbcs')
         else:
             bytestr = _strencode(str_filename)

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -1957,7 +1957,7 @@ open/create the Dataset. Requires netcdf >= 4.1.2"""
                 else:
                     # filepath on disk
                     decoded_path = py_path.decode(sys.getfilesystemencoding())
-		return decoded_path
+                return decoded_path
         ELSE:
             msg = """
 filepath method not enabled.  To enable, install Cython, make sure you have

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -941,6 +941,7 @@ import netcdftime
 import numpy
 import weakref
 import sys
+import urllib
 import warnings
 from glob import glob
 from numpy import ma
@@ -1950,7 +1951,13 @@ open/create the Dataset. Requires netcdf >= 4.1.2"""
                 py_path = c_path[:pathlen] # makes a copy of pathlen bytes from c_string
             finally:
                 free(c_path)
-            return py_path.decode('ascii')
+                if self.disk_format.startswith('DAP'):
+                    # OpenDAP-Datasource
+                    decoded_path = urllib.parse.unquote(py_path)
+                else:
+                    # filepath on disk
+                    decoded_path = py_path.decode(sys.getfilesystemencoding())
+		return decoded_path
         ELSE:
             msg = """
 filepath method not enabled.  To enable, install Cython, make sure you have

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -1951,13 +1951,15 @@ open/create the Dataset. Requires netcdf >= 4.1.2"""
                 py_path = c_path[:pathlen] # makes a copy of pathlen bytes from c_string
             finally:
                 free(c_path)
-                if self.disk_format.startswith('DAP'):
-                    # OpenDAP-Datasource
-                    decoded_path = urllib.parse.unquote(py_path)
-                else:
-                    # filepath on disk
-                    decoded_path = py_path.decode(sys.getfilesystemencoding())
-                return decoded_path
+
+            if self.disk_format.startswith('DAP'):
+                # OpenDAP-Datasource
+                decoded_path = urllib.parse.unquote(py_path)
+            else:
+                # filepath on disk
+                decoded_path = py_path.decode(sys.getfilesystemencoding())
+            return decoded_path
+
         ELSE:
             msg = """
 filepath method not enabled.  To enable, install Cython, make sure you have

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -1796,9 +1796,9 @@ references to the parent Dataset or Group.
             #diskless = False # don't raise error, instead silently ignore
             raise ValueError('diskless mode requires netcdf lib >= 4.2.1, you have %s' % __netcdf4libversion__)
         if sys.platform == 'win32':
-            bytestr = _strencode(str_filename, encoding='mbcs')
+            bytestr = _strencode(filename, encoding='mbcs')
         else:
-            bytestr = _strencode(str_filename)
+            bytestr = _strencode(filename)
 
         path = bytestr
 

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -1795,7 +1795,11 @@ references to the parent Dataset or Group.
         if diskless and __netcdf4libversion__ < '4.2.1':
             #diskless = False # don't raise error, instead silently ignore
             raise ValueError('diskless mode requires netcdf lib >= 4.2.1, you have %s' % __netcdf4libversion__)
-        bytestr = _strencode(str(filename), encoding=sys.getfilesystemencoding())
+        if sys.platform == 'win32:
+            bytestr = _strencode(str_filename, encoding='mbcs')
+        else:
+            bytestr = _strencode(str_filename)
+
         path = bytestr
 
         if memory is not None and (mode != 'r' or type(memory) != bytes):
@@ -1957,7 +1961,10 @@ open/create the Dataset. Requires netcdf >= 4.1.2"""
                 decoded_path = urllib.parse.unquote(py_path)
             else:
                 # filepath on disk
-                decoded_path = py_path.decode(sys.getfilesystemencoding())
+                if sys.platform == 'win32':
+                    decoded_path = py_path.decode('mbcs')
+                else:
+                    decoded_path = py_path.decode('utf-8')
             return decoded_path
 
         ELSE:

--- a/test/tst_filepath.py
+++ b/test/tst_filepath.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 import unittest
 import tempfile

--- a/test/tst_filepath.py
+++ b/test/tst_filepath.py
@@ -16,15 +16,20 @@ class test_filepath(unittest.TestCase):
 
     def test_filepath_with_non_ascii_characters(self):
         # create nc-file in a filepath with Non-Ascii-Characters
-        tempdir = tempfile.mkdtemp(prefix='ÄÖÜß_')
-        nc_non_ascii_file = os.path.join(tempdir, "Besançonalléestraße.nc")
-        nc_non_ascii = netCDF4.Dataset(nc_non_ascii_file, 'w')
+        tempdir = tempfile.mkdtemp(prefix=u'ÄÖÜß_')
+        filename = u"Besançonalléestraße.nc"
+        nc_non_ascii_file = os.path.join(tempdir, filename)
+        try:
+            nc_non_ascii = netCDF4.Dataset(nc_non_ascii_file, 'w')
+        except OSError:
+            msg = u'cannot create file {} in folder {}'.format(tempdir, filename)
+            raise OSError(msg)
         
         # test that no UnicodeDecodeError occur in the filepath() method
-        msg = 'original: {}\nstr_orig: {}\nfilepath: {}'.format(nc_non_ascii_file,
-                                                                str(nc_non_ascii_file), 
-                                                                nc_non_ascii.filepath())
-        assert nc_non_ascii.filepath() == str(nc_non_ascii_file), msg
+        msg = u'original: {}\nstr_orig: {}\nfilepath: {}'.format(
+            nc_non_ascii_file,
+            nc_non_ascii.filepath())
+        assert nc_non_ascii.filepath() == nc_non_ascii_file, msg
         
         # cleanup
         nc_non_ascii.close()

--- a/test/tst_filepath.py
+++ b/test/tst_filepath.py
@@ -21,7 +21,10 @@ class test_filepath(unittest.TestCase):
         nc_non_ascii = netCDF4.Dataset(nc_non_ascii_file, 'w')
         
         # test that no UnicodeDecodeError occur in the filepath() method
-        assert nc_non_ascii.filepath() == str(nc_non_ascii_file)
+        msg = 'original: {}\nstr_orig: {}\nfilepath: {}'.format(nc_non_ascii_file,
+                                                                str(nc_non_ascii_file), 
+                                                                nc_non_ascii.filepath())
+        assert nc_non_ascii.filepath() == str(nc_non_ascii_file), msg
         
         # cleanup
         nc_non_ascii.close()

--- a/test/tst_filepath.py
+++ b/test/tst_filepath.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
 import unittest
 import tempfile
 import netCDF4
@@ -22,7 +23,8 @@ class test_filepath(unittest.TestCase):
         try:
             nc_non_ascii = netCDF4.Dataset(nc_non_ascii_file, 'w')
         except OSError:
-            msg = u'cannot create file {} in folder {}'.format(tempdir, filename)
+            msg = u'cannot create file {} in folder {}\n using encoding: {}'.format(
+                tempdir, filename, sys.getfilesystemencoding())
             raise OSError(msg)
         
         # test that no UnicodeDecodeError occur in the filepath() method

--- a/test/tst_filepath.py
+++ b/test/tst_filepath.py
@@ -16,6 +16,11 @@ class test_filepath(unittest.TestCase):
         assert self.nc.filepath() == str(self.netcdf_file)
 
     def test_filepath_with_non_ascii_characters(self):
+        python3 = sys.version_info[0] > 2
+        if python3:
+            encoding = 'utf-8'
+        else:
+            encoding = 'mbsc'
         # create nc-file in a filepath with Non-Ascii-Characters
         tempdir = tempfile.mkdtemp(prefix=u'ÄÖÜß_')
         filename = u"Besançonalléestraße.nc"
@@ -24,11 +29,11 @@ class test_filepath(unittest.TestCase):
             nc_non_ascii = netCDF4.Dataset(nc_non_ascii_file, 'w')
         except OSError:
             msg = u'cannot create file {} in folder {}\n using encoding: {}'.format(
-                tempdir, filename, sys.getfilesystemencoding())
+                tempdir, filename, encoding)
             raise OSError(msg)
         
         # test that no UnicodeDecodeError occur in the filepath() method
-        msg = u'original: {}\nstr_orig: {}\nfilepath: {}'.format(
+        msg = u'original: {}\nfilepath: {}'.format(
             nc_non_ascii_file,
             nc_non_ascii.filepath())
         assert nc_non_ascii.filepath() == nc_non_ascii_file, msg


### PR DESCRIPTION
fixes file encoding and decodes the filepath from the default filesystemencoding - or form percentage-encoding if it is a OpenDAV Datasource