### PR TITLE
The issue was already fixed.

### DIFF
--- a/netCDF4/utils.py
+++ b/netCDF4/utils.py
@@ -180,10 +180,11 @@ def _StartCountStride(elem, shape, dimensions=None, grp=None, datashape=None,\
 
     # replace boolean arrays with sequences of integers.
     newElem = []
+    i=0
     IndexErrorMsg=\
     "only integers, slices (`:`), ellipsis (`...`), and 1-d integer or boolean arrays are valid indices"
     idim = -1
-    for i, e in enumerate(elem):
+    for e in elem:
         # which dimension is this?
         if type(e) == type(Ellipsis):
             idim = nDims - len(elem) + idim + 1
@@ -268,6 +269,10 @@ Boolean array must have the same shape as the data along this dimension."""
                 newElem.append(e)
             except:
                 raise IndexError(IndexErrorMsg)
+        if type(e)==type(Ellipsis):
+            i+=1+nDims-len(elem)
+        else:
+            i+=1
     elem = newElem
 
     # replace Ellipsis and integer arrays with slice objects, if possible.


### PR DESCRIPTION
The count variable, i, didn't take into account the "variable length" of an input ellipsis so that the length of an  index array was sometimes compared to the length of wrong dimension, which sometimes resulted in IndexError("integer index exceeds dimension size"). I believe that the rest of the code work correctly and that it was only a bug in the "input check".