### PR TITLE
Add optional calendar overload to MFTime

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,10 @@
    IO can be toggled between collective and independent using `Variable.set_collective`.
    See `examples/mpi_example.py`. Issue #717, pull request #716.
    Minimum cython dependency bumped from 0.19 to 0.21.
+ * Add optional `MFTime` calendar overload to use across all files, for example,
+   `'standard'` or `'gregorian'`. If `None` (the default), check that the calendar
+   attribute is present on each variable and values are unique across files raising
+   a `ValueError` otherwise.
 
  version 1.3.0 (tag v1.3.0rel)
 ==============================


### PR DESCRIPTION
I decided to go with `calendar=None` as the default to handle the time bounds case with no surprises. If standard was the default, a bounds variable associated with a time centroid having a non-standard calendar would produce unexpected behavior (if the user went with the default). Let me know if you think standard should be used instead!

Addresses #720.