### PR TITLE
pass errno and optional args to exceptions

### DIFF
--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -1632,7 +1632,7 @@ cdef _ensure_nc_success(ierr, err_cls=RuntimeError, filename=None):
     # print netcdf error message, raise error.
     if ierr != NC_NOERR:
         err_str = (<char *>nc_strerror(ierr)).decode('ascii')
-        if isinstance(err_cls, EnvironmentError):
+        if issubclass(err_cls, EnvironmentError):
             raise err_cls(ierr, err_str, filename)
         else:
             raise err_cls(err_str)

--- a/test/tst_filepath.py
+++ b/test/tst_filepath.py
@@ -26,7 +26,7 @@ class test_filepath(unittest.TestCase):
 
     def test_no_such_file_raises(self):
         fname = 'not_a_nc_file.nc'
-        with self.assertRaisesRegex(IOError, fname):
+        with self.assertRaisesRegexp(IOError, fname):
             netCDF4.Dataset(fname, 'r')
 
 

--- a/test/tst_filepath.py
+++ b/test/tst_filepath.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 import netCDF4
 
+
 class test_filepath(unittest.TestCase):
 
     def setUp(self):
@@ -22,6 +23,12 @@ class test_filepath(unittest.TestCase):
         assert filepath.encode('cp1252') == filepatho.encode('cp1252')
         nc.close()
         shutil.rmtree(tmpdir)
+
+    def test_no_such_file_raises(self):
+        fname = 'not_a_nc_file.nc'
+        with self.assertRaisesRegex(IOError, fname):
+            netCDF4.Dataset(fname, 'r')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- [x] Closes https://github.com/pydata/xarray/pull/1622 
- [x] Tests added / passed
- [x] Passes ``git diff upstream/master | flake8 --diff``

We're finding that the current "FileNotFoundError" handling in netCDF4 is not sufficiently informative (see above xarray issue). 

```
In [1]: from netCDF4 import Dataset

In [2]: Dataset('not a file')
---------------------------------------------------------------------------
OSError                                   Traceback (most recent call last)
<ipython-input-2-b0f2bfa73c00> in <module>()
----> 1 Dataset('not a file')

netCDF4/_netCDF4.pyx in netCDF4._netCDF4.Dataset.__init__()

netCDF4/_netCDF4.pyx in netCDF4._netCDF4._ensure_nc_success()

OSError: No such file or directory
```

Where we'd ideally raise a more informative error 
```Python-traceback
FileNotFoundError: No such file or directory: "not a file"
```

This PR does two things:

1) it passes the netCDF error code to each Error Class. This is particularly important for IOErrors but also adds some additional information to the other error classes.
2) allows a series of optional positional arguments (e.g. filename) that the error class can use.

cc @shoyer 