### PR TITLE
always return a masked array be default

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -25,6 +25,9 @@
    array dtypes with 'SN' string subtypes can now be used to
    define netcdf compound types (they get converted to ('S1',N)
    character array types automatically).
+ * always return masked array by default, even if there are no 
+   masked values (too surprising to get ndarray or MaskedArray depending
+   on slice, issue #785).
  
 
  version 1.3.1 (tag v1.3.1rel)

--- a/test/tst_fancyslicing.py
+++ b/test/tst_fancyslicing.py
@@ -112,7 +112,9 @@ class VariablesTestCase(unittest.TestCase):
         # Empty boolean -- all False
         d1 = f.variables['data1']
         m = np.zeros(xdim, bool)
-        assert_equal(d1[m], ())
+        if np.__version__ > '1.9.0':
+            # fails for old numpy versions
+            assert_equal(d1[m], ())
 
         # Check that no assignment is made
         d1[m] = 0

--- a/test/tst_scaled.py
+++ b/test/tst_scaled.py
@@ -63,7 +63,8 @@ class SetAutoScaleFalse(SetAutoScaleTestBase):
 
         self.assertEqual(v.dtype, "i2")
         self.assertTrue(isinstance(v, np.ndarray))
-        self.assertTrue(not isinstance(v, ma.core.MaskedArray))
+        # issue 785: always return masked array by default
+        self.assertTrue(isinstance(v, ma.core.MaskedArray))
         assert_array_almost_equal(v, self.v)
 
         f.close()
@@ -107,7 +108,8 @@ class SetAutoScaleTrue(SetAutoScaleTestBase):
 
         self.assertEqual(v_scaled.dtype, "f8")
         self.assertTrue(isinstance(v_scaled, np.ndarray))
-        self.assertTrue(not isinstance(v_scaled, ma.core.MaskedArray))
+        # issue 785: always return masked array by default
+        self.assertTrue(isinstance(v_scaled, ma.core.MaskedArray))
         assert_array_almost_equal(v_scaled, self.v_scaled)
         f.close()
 

--- a/test/tst_slicing.py
+++ b/test/tst_slicing.py
@@ -94,6 +94,10 @@ class VariablesTestCase(unittest.TestCase):
         v[...] = 10
         assert_array_equal(v[...], 10)
         assert_equal(v.shape, v[...].shape)
+        # issue #785: always return masked array
+        #assert(type(v[...]) == np.ndarray)
+        assert(type(v[...]) == np.ma.core.MaskedArray)
+        f.set_auto_mask(False)
         assert(type(v[...]) == np.ndarray)
         f.close()
 


### PR DESCRIPTION
Issue #785 points out that by default, either a `numpy.ma.core.MaskedArray` or a `numpy.ndarray` can be returned, depending on whether the slice contains any missing values.  This pull request ensures that a  `numpy.ma.core.MaskedArray` is always returned, unless `set_auto_mask(False)` is invoked and then a `numpy.ndarray`  is always returned.