### PR TITLE
netCDF4/utils.py bug fixed to call _getgrp 

### DIFF
--- a/netCDF4/utils.py
+++ b/netCDF4/utils.py
@@ -527,9 +527,9 @@ def ncinfo():
                 print(f.dimensions[dim])
     else:
         if var is None and dim is None:
-            print(getgrp(f,group))
+            print(_getgrp(f,group))
         else:
-            g = getgrp(f,group)
+            g = _getgrp(f,group)
             if var is not None:
                 print(g.variables[var])
             if dim is not None:


### PR DESCRIPTION
A bug fixed to call _getgrp function inside netCDF4/utils.py
Before this fix, ncinfo command does not provide group information of a netcdf4 dataset.