### PR TITLE
disable workaround for slow nc_get_vars if lib version >=4.6.2

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,8 @@
+ since version 1.4.0 (not yet released)
+=============================
+ * disable workaround for slow nc_get_vars for __netcdflibversion__ >= 4.6.2,
+   since a fix was added to speed up nc_get_vars in the C library.  Issue 680.
+
  version 1.4.0 (tag v1.4.0rel)
 =============================
  * fixed bug in detection of CDF5 library support in setup.py (pull request

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -3606,7 +3606,12 @@ behavior is similar to Fortran or Matlab, but different than numpy.
         if 'least_significant_digit' in self.ncattrs():
             self._has_lsd = True
         # avoid calling nc_get_vars for strided slices by default.
-        self._no_get_vars = True
+        # a fix for strided slice access using HDF5 was added
+        # in 4.6.2.
+        if __netcdf4libversion__ >= "4.6.2":
+            self._no_get_vars = False
+        else:
+            self._no_get_vars = True
 
     def __array__(self):
         # numpy special method that returns a numpy array.

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -4639,8 +4639,9 @@ The default value of `chartostring` is `True`
 
 enable the use of netcdf library routine `nc_get_vars`
 to retrieve strided variable slices.  By default,
-`nc_get_vars` not used since it slower than multiple calls
-to the unstrided read routine `nc_get_vara` in most cases.
+`nc_get_vars` may not used by default (depending on the
+version of the netcdf-c library being used) since it may be
+slower than multiple calls to the unstrided read routine `nc_get_vara`.
         """
         self._no_get_vars = not bool(use_nc_get_vars)
         


### PR DESCRIPTION
update to issues #680, #683