### PR TITLE
test against latest numpy

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,11 +2,11 @@ environment:
   CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
   matrix:
     - TARGET_ARCH: x64
-      NPY: 1.15
+      NPY: 1.16
       PY: 3.6
 
     - TARGET_ARCH: x64
-      NPY: 1.15
+      NPY: 1.16
       PY: 3.7
 
 platform:


### PR DESCRIPTION
@jswhit we should update this every-now-and-then just to be sure Windows is OK with latest `numpy` too. (Although you will probably catch any `numpy` changes in the Linux tests as well.)