### PR TITLE
Feature/read shared

### DIFF
--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -1998,7 +1998,7 @@ strings.
         modified. `w` means write; a new file is created, an existing file with
         the same name is deleted. `a` and `r+` mean append (in analogy with
         serial files); an existing file is opened for reading and writing.
-        Appending `s` to modes `w`, `r+` or `a` will enable unbuffered shared
+        Appending `s` to modes `r`, `w`, `r+` or `a` will enable unbuffered shared
         access to `NETCDF3_CLASSIC`, `NETCDF3_64BIT_OFFSET` or
         `NETCDF3_64BIT_DATA` formatted files.
         Unbuffered access may be useful even if you don't need shared

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -2179,7 +2179,7 @@ strings.
             # **this causes parallel mode to fail when both hdf5-parallel and
             # pnetcdf are enabled - issue #820 **
             #_set_default_format(format='NETCDF3_64BIT_OFFSET')
-        elif mode == 'r':
+        elif mode in ('r', 'rs'):
             if memory is not None:
                 IF HAS_NC_OPEN_MEM:
                     # Store reference to memory
@@ -2202,7 +2202,12 @@ strings.
             elif diskless:
                 ierr = nc_open(path, NC_NOWRITE | NC_DISKLESS, &grpid)
             else:
-                ierr = nc_open(path, NC_NOWRITE, &grpid)
+		if mode == 'rs':
+                    # NC_SHARE is very important for reading large
+                    # netcdf files
+                    ierr = nc_open(path, NC_NOWRITE | NC_SHARE, &grpid)
+		else:
+                    ierr = nc_open(path, NC_NOWRITE, &grpid)
         elif mode == 'r+' or mode == 'a':
             if parallel:
                 IF HAS_NC_PAR:

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -1991,8 +1991,8 @@ strings.
         `netCDF4.Dataset` constructor.
 
         **`filename`**: Name of netCDF file to hold dataset. Can also
-	be a python 3 pathlib instance or the URL of an OpenDAP dataset.  When memory is
-	set this is just used to set the `filepath()`.
+        be a python 3 pathlib instance or the URL of an OpenDAP dataset.  When memory is
+        set this is just used to set the `filepath()`.
 
         **`mode`**: access mode. `r` means read-only; no data can be
         modified. `w` means write; a new file is created, an existing file with
@@ -2202,11 +2202,13 @@ strings.
             elif diskless:
                 ierr = nc_open(path, NC_NOWRITE | NC_DISKLESS, &grpid)
             else:
-		if mode == 'rs':
-                    # NC_SHARE is very important for reading large
-                    # netcdf files
+                if mode == 'rs':
+                    # NC_SHARE is very important for speed reading
+                    # large netcdf3 files with a record dimension.
+                    # Opening as r+s or as implies capability to
+                    # which may be inconsistent with actual access
                     ierr = nc_open(path, NC_NOWRITE | NC_SHARE, &grpid)
-		else:
+                else:
                     ierr = nc_open(path, NC_NOWRITE, &grpid)
         elif mode == 'r+' or mode == 'a':
             if parallel:


### PR DESCRIPTION
Adding read shared mode.

netCDF4.Dataset currently has append shared, but no read shared. There are two circumstances that require read shared. First, read shared provides access to edits made by other programs as they become available. Second, read shared makes reading faster than read.

Shared is already available through append (as or r+s), but this leads to confusion when the user does not want append access. By enabling append, the user may accidentally make edits to a file. This creates a hesitancy to use as or r+s even when a program may be enhanced dramatically.

I tested a NetCDF3 file with:
TSTEP = 744
ROW = 299
COL = 459

With `r`, the file took 14 seconds to read a single variable (all times). With `rs`, the file took less than a second.