### PR TITLE
Refactor Python 3.7+ to use dict built-in instead of OrderedDict

### DIFF
--- a/test/tst_atts.py
+++ b/test/tst_atts.py
@@ -7,13 +7,10 @@ import tempfile
 import warnings
 
 import numpy as NP
+from collections import OrderedDict
 from numpy.random.mtrand import uniform
-import netCDF4
 
-try:
-    from collections import OrderedDict
-except ImportError: # or else use drop-in substitute
-    from ordereddict import OrderedDict
+import netCDF4
 
 # test attribute creation.
 FILE_NAME = tempfile.NamedTemporaryFile(suffix='.nc', delete=False).name


### PR DESCRIPTION
A nice [feature of Python 3.7](https://docs.python.org/3/whatsnew/3.7.html) is that insertion order for `dict` objects is guaranteed. This means that `OrderedDict` is no longer needed to preserve this behavior.

One good benefit of using the standard `dict` is that it has a more compact string representation (e.g. `OrderedDict([('b', 1), ('a', 2)])` vs `{'b': 1, 'a': 2}`)

For Python 2.7-3.6, `OrderedDict` is part of `collections` module, which simplifies this import.