### PR TITLE
Remove underline from variable name in Dataset string repr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,9 @@ build/
 dist/
 *.egg-info/
 netCDF4/_netCDF4.c
+netCDF4/*.so
 include/constants.pyx
 netcdftime/_netcdftime.c
+venv/
+.eggs/
+.idea/

--- a/Changelog
+++ b/Changelog
@@ -1,7 +1,12 @@
  version 1.5.2 (not yet released)
 ==============================
- * fix for scaling bug when _Unsigned attribute is set and byteorder of data does not
-   match native byteorder (issue #930).
+ * fix for scaling bug when _Unsigned attribute is set and byteorder of data
+   does not match native byteorder (issue #930).
+ * revise documentation for Python 3 (issue #946).
+ * establish support for Python 2.7, 3.5, 3.6 and 3.7 (issue #948).
+ * use dict built-in instead of OrderedDict for Python 3.7+
+   (pull request #955).
+ * remove underline ANSI in Dataset string representation (pull request #956)
 
  version 1.5.1.2 (tag v1.5.1.2rel)
 ==================================

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -395,9 +395,10 @@ You can also query a `netCDF4.Dataset` or `netCDF4.Group` instance directly to o
     >>> print(rootgrp["/forecasts/model1"])  # a Group instance
     <class 'netCDF4._netCDF4.Group'>
     group /forecasts/model1:
-        dimensions(sizes):
+        dimensions(sizes): 
         variables(dimensions): float32 temp(time,level,lat,lon)
-        groups:
+        groups: 
+    <BLANKLINE>
     >>> print(rootgrp["/forecasts/model1/temp"])  # a Variable instance
     <class 'netCDF4._netCDF4.Variable'>
     float32 temp(time, level, lat, lon)
@@ -786,7 +787,7 @@ objects gives useful summary information in an interactive session:
     <class 'netCDF4._netCDF4.Dataset'>
     root group (NETCDF4 data model, file format HDF5):
         dimensions(sizes): x_dim(3)
-        variables(dimensions): {'names':['real','imag'], 'formats':['<f8','<f8'], 'offsets':[0,8], 'itemsize':16, 'aligned':True} ESC[4mcmplx_varESC[0m(x_dim)
+        variables(dimensions): {'names':['real','imag'], 'formats':['<f8','<f8'], 'offsets':[0,8], 'itemsize':16, 'aligned':True} cmplx_var(x_dim)
         groups: 
     <BLANKLINE>
     >>> print(f.variables["cmplx_var"])
@@ -856,7 +857,7 @@ In this case, they contain 1-D numpy `int32` arrays of random length between
     <class 'netCDF4._netCDF4.Dataset'>
     root group (NETCDF4 data model, file format HDF5):
         dimensions(sizes): x(3), y(4)
-        variables(dimensions): int32 ESC[4mphony_vlen_varESC[0m(y,x)
+        variables(dimensions): int32 phony_vlen_var(y,x)
         groups: 
     <BLANKLINE>
     >>> print(f.variables["phony_vlen_var"])
@@ -2447,7 +2448,7 @@ version 4.1.2 or higher of the netcdf C lib, and rebuild netcdf4-python."""
         dimnames = tuple([_tostr(dimname)+'(%s)'%len(self.dimensions[dimname])\
         for dimname in self.dimensions.keys()])
         varnames = tuple(\
-        [_tostr(self.variables[varname].dtype)+' \033[4m'+_tostr(varname)+'\033[0m'+
+        [_tostr(self.variables[varname].dtype)+' '+_tostr(varname)+
         (((_tostr(self.variables[varname].dimensions)
         .replace("u'",""))\
         .replace("'",""))\


### PR DESCRIPTION
While preparing #950, variable names were underlined using cleaver ANSI escape sequences. However, this was only done for Dataset, and not other classes. It is generally preferred to have `__repr__` return common strings (e.g. ascii), so I'm suggesting these to be removed. Not all interfaces support ANSI escape codes, so a odd-looking  `ESC[4mcmplx_varESC[0m` will be returned instead of `cmplx_var`.

However, happy to discuss further.