### PR TITLE
#964 Removed the 4 from the pattern that is used to decide if the underlyi…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ def check_api(inc_dirs):
             for line in open(ncmetapath):
                 if line.startswith('#define NC_HAS_CDF5'):
                     has_cdf5_format = bool(int(line.split()[2]))
-                elif line.startswith('#define NC_HAS_PARALLEL4'):
+                elif line.startswith('#define NC_HAS_PARALLEL'):
                     has_parallel4_support = bool(int(line.split()[2]))
                 elif line.startswith('#define NC_HAS_PNETCDF'):
                     has_pnetcdf_support = bool(int(line.split()[2]))


### PR DESCRIPTION
…ng netcdf has been compiled with parallel support since in my version 4.6.1 the includefile "netcdf_meta.h" also does not have it. This caused setup.py to report wrongly that the underlying c lib had been built without parallel support.