### PR TITLE
_ncstring_attrs__ is not a kwarg of Dataset.__init__

### DIFF
--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -2094,10 +2094,6 @@ strings.
         desirable, since the associated Variable instances may still be needed, but are
         rendered unusable when the parent Dataset instance is garbage collected.
 
-        **`_ncstring_attrs__`**: if `_ncstring_attrs__=True`, all string attributes will use
-        the variable length NC_STRING attributes (default `False`, ascii text
-        attributes written as NC_CHAR).
-
         **`memory`**: if not `None`, create or open an in-memory Dataset.
         If mode = 'r', the memory kwarg must contain a memory buffer object
         (an object that supports the python buffer interface).


### PR DESCRIPTION
In #882 it was decided not to have `_ncstring_attrs__` be a keyword argument for `Dataset.__init__`, but the docstring for `Dataset.__init__` still said it was a keyword arg.