### PR TITLE
Replaces use of numpy's tostring() with tobytes()

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -9,6 +9,8 @@
  * check size on valid_range instead of using len (issue #1013).
  * add `set_chunk_cache/get_chunk_cache` module functions to reset the
    default chunk cache sizes before opening a Dataset (issue #1018).
+ * replace use of numpy's deprecated tostring() method with tobytes()
+   (issue #1023).
 
  version 1.5.3 (tag v1.5.3rel)
 ==============================

--- a/netCDF4/_netCDF4.pyx
+++ b/netCDF4/_netCDF4.pyx
@@ -1455,10 +1455,10 @@ cdef _get_att(grp, int varid, name, encoding='utf-8'):
         if name == '_FillValue' and python3:
             # make sure _FillValue for character arrays is a byte on python 3
             # (issue 271).
-            pstring = value_arr.tostring()
+            pstring = value_arr.tobytes()
         else:
             pstring =\
-            value_arr.tostring().decode(encoding,errors='replace').replace('\x00','')
+            value_arr.tobytes().decode(encoding,errors='replace').replace('\x00','')
         return pstring
     elif att_type == NC_STRING:
         values = <char**>PyMem_Malloc(sizeof(char*) * att_len)
@@ -6133,9 +6133,9 @@ and shape `a.shape + (N,)`, where N is the length of each string in a."""
     if dtype not in ["S","U"]:
         raise ValueError("type must string or unicode ('S' or 'U')")
     if encoding in ['none','None','bytes']:
-        b = numpy.array(tuple(a.tostring()),'S1')
+        b = numpy.array(tuple(a.tobytes()),'S1')
     else:
-        b = numpy.array(tuple(a.tostring().decode(encoding)),dtype+'1')
+        b = numpy.array(tuple(a.tobytes().decode(encoding)),dtype+'1')
     b.shape = a.shape + (a.itemsize,)
     return b
 
@@ -6159,9 +6159,9 @@ returns a numpy string array with datatype `'UN'` (or `'SN'`) and shape
     if dtype not in ["S","U"]:
         raise ValueError("type must be string or unicode ('S' or 'U')")
     if encoding in ['none','None','bytes']:
-        bs = b.tostring()
+        bs = b.tobytes()
     else:
-        bs = b.tostring().decode(encoding)
+        bs = b.tobytes().decode(encoding)
     slen = int(b.shape[-1])
     if encoding in ['none','None','bytes']:
         a = numpy.array([bs[n1:n1+slen] for n1 in range(0,len(bs),slen)],'S'+repr(slen))


### PR DESCRIPTION
numpy has deprecated the use of array.array.tostring() in favor of
tobytes
https://github.com/numpy/numpy/pull/15867
This patch replaces all (6) such uses in this package.

Fixes #1023 

I haven't done extensive testing, but the test suite runs fine on my dev machine:

```
(venv) james@basalt:~/code/git/netcdf4-python/test$ python run_all.py 
not running tst_unicode.py ...
not running tst_create_mem.py ...
not running tst_cdf5.py ...

netcdf4-python version: 1.5.4
HDF5 lib version:       1.10.0
netcdf lib version:     4.6.0
numpy version           1.19.0
cython version          0.29.20
......../home/james/code/git/netcdf4-python/test/tst_types.py:92: UserWarning: WARNING: missing_value not used since it
cannot be safely cast to variable data type
  assert_array_equal(v3[:],-1*np.ones(n2dim,v3.dtype))
..................................................................................foo_bar
.
----------------------------------------------------------------------
Ran 91 tests in 4.479s

OK
```