### PR TITLE
Enhance setup.py

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -12,8 +12,6 @@
  * replace use of numpy's deprecated tostring() method with tobytes()
    (issue #1023).
  * bump minimal numpy version to 1.9
- * add CONDA_PREFIX to the directories that are searched for HDF5 headers by
-   setup.py
 
  version 1.5.3 (tag v1.5.3rel)
 ==============================

--- a/Changelog
+++ b/Changelog
@@ -11,6 +11,9 @@
    default chunk cache sizes before opening a Dataset (issue #1018).
  * replace use of numpy's deprecated tostring() method with tobytes()
    (issue #1023).
+ * bump minimal numpy version to 1.9
+ * add CONDA_PREFIX to the directories that are searched for HDF5 headers by
+   setup.py
 
  version 1.5.3 (tag v1.5.3rel)
 ==============================

--- a/setup.py
+++ b/setup.py
@@ -362,8 +362,8 @@ def _populate_hdf5_info(dirstosearch, inc_dirs, libs, lib_dirs):
         libs.extend(['hdf5_hl', 'hdf5'])
 
 
-dirstosearch = [os.path.expanduser('~'), '/usr/local', '/sw', '/opt',
-                '/opt/local', '/usr', os.getenv("CONDA_PREFIX", "")]
+dirstosearch = [os.getenv("CONDA_PREFIX", ""), os.path.expanduser('~'),
+                '/usr/local', '/sw', '/opt', '/opt/local', '/usr']
 
 if not retcode:  # Try nc-config.
     sys.stdout.write('using nc-config ...\n')

--- a/setup.py
+++ b/setup.py
@@ -362,8 +362,8 @@ def _populate_hdf5_info(dirstosearch, inc_dirs, libs, lib_dirs):
         libs.extend(['hdf5_hl', 'hdf5'])
 
 
-dirstosearch = [os.path.expanduser('~'), '/usr/local', '/sw',
-                '/opt', '/opt/local', '/usr']
+dirstosearch = [os.path.expanduser('~'), '/usr/local', '/sw', '/opt',
+                '/opt/local', '/usr']
 
 if not retcode:  # Try nc-config.
     sys.stdout.write('using nc-config ...\n')

--- a/setup.py
+++ b/setup.py
@@ -362,8 +362,8 @@ def _populate_hdf5_info(dirstosearch, inc_dirs, libs, lib_dirs):
         libs.extend(['hdf5_hl', 'hdf5'])
 
 
-dirstosearch = [os.getenv("CONDA_PREFIX", ""), os.path.expanduser('~'),
-                '/usr/local', '/sw', '/opt', '/opt/local', '/usr']
+dirstosearch = [os.path.expanduser('~'), '/usr/local', '/sw',
+                '/opt', '/opt/local', '/usr']
 
 if not retcode:  # Try nc-config.
     sys.stdout.write('using nc-config ...\n')

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, Extension
 from distutils.dist import Distribution
 
 setuptools_extra_kwargs = {
-    "install_requires": ["numpy>=1.7","cftime"],
+    "install_requires": ["numpy>=1.9","cftime"],
     "setup_requires": ['setuptools>=18.0', "cython>=0.19"],
     "entry_points": {
         'console_scripts': [
@@ -363,7 +363,7 @@ def _populate_hdf5_info(dirstosearch, inc_dirs, libs, lib_dirs):
 
 
 dirstosearch = [os.path.expanduser('~'), '/usr/local', '/sw', '/opt',
-                '/opt/local', '/usr']
+                '/opt/local', '/usr', os.getenv("CONDA_PREFIX", "")]
 
 if not retcode:  # Try nc-config.
     sys.stdout.write('using nc-config ...\n')


### PR DESCRIPTION
Since #1024 this package uses `tobytes()`, however this function only exists for `numpy>=1.9` ([numpy release note reference](https://numpy.org/doc/stable/release/1.19.0-notes.html#numpy-ndarray-tostring-is-deprecated-in-favor-of-tobytes)).

This PR bumps the numpy version.

~While trying to fix this, I ran into the issue that a `pip install -e .` would not check my active `conda` environment for the presence of `HDF5` headers, so I also added that to the `setup.py`.~

