### PR TITLE
also search include dir parents for hdf5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -330,7 +330,9 @@ def _populate_hdf5_info(dirstosearch, inc_dirs, libs, lib_dirs):
         if HDF5_incdir is None and HDF5_dir is None:
             sys.stdout.write("""
     HDF5_DIR environment variable not set, checking some standard locations ..\n""")
-            for direc in dirstosearch:
+            # Add parents of include dir to dirstosearch and look there first
+            parentdirs = [os.path.join(direc, os.pardir) for direc in inc_dirs]
+            for direc in parentdirs + dirstosearch:
                 sys.stdout.write('checking %s ...\n' % direc)
                 hdf5_version = check_hdf5version(os.path.join(direc, 'include'))
                 if hdf5_version is None:


### PR DESCRIPTION
While trying to do a development install inside conda like this:
```
conda create -n test python=3
conda activate test
conda install netcdf4 --only-deps
pip install -e .
```
pip would find the installed libraries of `libnetcdf` inside the conda environment, but not for `hdf5`.

This PR makes it so that `inc_dirs` are also searched to look for hdf5, this is done before the standard dirs to make sure it aligns with where `libnetcdf` is found.

This is only done, if none if the environment variables is set.