### PR TITLE
Use numpy alias 'np' more consistently

### DIFF
--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -80,10 +80,10 @@ print(rootgrp.__dict__)
 
 print(rootgrp.variables)
 
-import numpy
+import numpy as np
 # no unlimited dimension, just assign to slice.
-lats =  numpy.arange(-90,91,2.5)
-lons =  numpy.arange(-180,180,2.5)
+lats =  np.arange(-90,91,2.5)
+lons =  np.arange(-180,180,2.5)
 latitudes[:] = lats
 longitudes[:] = lons
 print('latitudes =\n',latitudes[:])
@@ -123,7 +123,7 @@ for nfile in range(10):
     f = Dataset('mftest'+repr(nfile)+'.nc','w',format='NETCDF4_CLASSIC')
     f.createDimension('x',None)
     x = f.createVariable('x','i',('x',))
-    x[0:10] = numpy.arange(nfile*10,10*(nfile+1))
+    x[0:10] = np.arange(nfile*10,10*(nfile+1))
     f.close()
 # now read all those files in at once, in one Dataset.
 from netCDF4 import MFDataset
@@ -134,15 +134,15 @@ print(f.variables['x'][:])
 f = Dataset('complex.nc','w')
 size = 3 # length of 1-d complex array
 # create sample complex data.
-datac = numpy.exp(1j*(1.+numpy.linspace(0, numpy.pi, size)))
+datac = np.exp(1j*(1.+np.linspace(0, np.pi, size)))
 print(datac.dtype)
 # create complex128 compound data type.
-complex128 = numpy.dtype([('real',numpy.float64),('imag',numpy.float64)])
+complex128 = np.dtype([('real',np.float64),('imag',np.float64)])
 complex128_t = f.createCompoundType(complex128,'complex128')
 # create a variable with this data type, write some data to it.
 f.createDimension('x_dim',None)
 v = f.createVariable('cmplx_var',complex128_t,'x_dim')
-data = numpy.empty(size,complex128) # numpy structured array
+data = np.empty(size,complex128) # numpy structured array
 data['real'] = datac.real; data['imag'] = datac.imag
 v[:] = data
 # close and reopen the file, check the contents.
@@ -156,7 +156,7 @@ v = f.variables['cmplx_var']
 print(v.shape)
 datain = v[:] # read in all the data into a numpy structured array
 # create an empty numpy complex array
-datac2 = numpy.empty(datain.shape,numpy.complex128)
+datac2 = np.empty(datain.shape,np.complex128)
 # .. fill it with contents of structured array.
 datac2.real = datain['real']
 datac2.imag = datain['imag']
@@ -168,11 +168,11 @@ f = Dataset('compound_example.nc','w') # create a new dataset.
 # create an unlimited  dimension call 'station'
 f.createDimension('station',None)
 # define a compound data type (can contain arrays, or nested compound types).
-winddtype = numpy.dtype([('speed','f4'),('direction','i4')])
-statdtype = numpy.dtype([('latitude', 'f4'), ('longitude', 'f4'),
-                         ('surface_wind',winddtype),
-                         ('temp_sounding','f4',10),('press_sounding','i4',10),
-                         ('location_name','S12')])
+winddtype = np.dtype([('speed','f4'),('direction','i4')])
+statdtype = np.dtype([('latitude', 'f4'), ('longitude', 'f4'),
+                      ('surface_wind',winddtype),
+                      ('temp_sounding','f4',10),('press_sounding','i4',10),
+                      ('location_name','S12')])
 # use this data type definitions to create a compound data types
 # called using the createCompoundType Dataset method.
 # create a compound type for vector wind which will be nested inside
@@ -181,12 +181,12 @@ wind_data_t = f.createCompoundType(winddtype,'wind_data')
 # now that wind_data_t is defined, create the station data type.
 station_data_t = f.createCompoundType(statdtype,'station_data')
 # create nested compound data types to hold the units variable attribute.
-winddtype_units = numpy.dtype([('speed','S12'),('direction','S12')])
-statdtype_units = numpy.dtype([('latitude', 'S12'), ('longitude', 'S12'),
-                               ('surface_wind',winddtype_units),
-                               ('temp_sounding','S12'),
-                               ('location_name','S12'),
-                               ('press_sounding','S12')])
+winddtype_units = np.dtype([('speed','S12'),('direction','S12')])
+statdtype_units = np.dtype([('latitude', 'S12'), ('longitude', 'S12'),
+                            ('surface_wind',winddtype_units),
+                            ('temp_sounding','S12'),
+                            ('location_name','S12'),
+                            ('press_sounding','S12')])
 # create the wind_data_units type first, since it will nested inside
 # the station_data_units data type.
 wind_data_units_t = f.createCompoundType(winddtype_units,'wind_data_units')
@@ -195,7 +195,7 @@ f.createCompoundType(statdtype_units,'station_data_units')
 # create a variable of of type 'station_data_t'
 statdat = f.createVariable('station_obs', station_data_t, ('station',))
 # create a numpy structured array, assign data to it.
-data = numpy.empty(1,statdtype)
+data = np.empty(1,statdtype)
 data['latitude'] = 40.
 data['longitude'] = -105.
 data['surface_wind']['speed'] = 12.5
@@ -207,12 +207,12 @@ data['location_name'] = 'Boulder, CO'
 statdat[0] = data
 # or just assign a tuple of values to variable slice
 # (will automatically be converted to a structured array).
-statdat[1] = numpy.array((40.78,-73.99,(-12.5,90),
+statdat[1] = np.array((40.78,-73.99,(-12.5,90),
              (290.2,282.5,279.,277.9,276.,266.,264.1,260.,255.5,243.),
              range(900,400,-50),'New York, NY'),data.dtype)
 print(f.cmptypes)
-windunits = numpy.empty(1,winddtype_units)
-stationobs_units = numpy.empty(1,statdtype_units)
+windunits = np.empty(1,winddtype_units)
+stationobs_units = np.empty(1,statdtype_units)
 windunits['speed'] = 'm/s'
 windunits['direction'] = 'degrees'
 stationobs_units['latitude'] = 'degrees N'
@@ -235,15 +235,15 @@ print(statdat[:])
 f.close()
 
 f = Dataset('tst_vlen.nc','w')
-vlen_t = f.createVLType(numpy.int32, 'phony_vlen')
+vlen_t = f.createVLType(np.int32, 'phony_vlen')
 x = f.createDimension('x',3)
 y = f.createDimension('y',4)
 vlvar = f.createVariable('phony_vlen_var', vlen_t, ('y','x'))
 import random
-data = numpy.empty(len(y)*len(x),object)
+data = np.empty(len(y)*len(x),object)
 for n in range(len(y)*len(x)):
-    data[n] = numpy.arange(random.randint(1,10),dtype='int32')+1
-data = numpy.reshape(data,(len(y),len(x)))
+    data[n] = np.arange(random.randint(1,10),dtype='int32')+1
+data = np.reshape(data,(len(y),len(x)))
 vlvar[:] = data
 print(vlvar)
 print('vlen variable =\n',vlvar[:])
@@ -253,7 +253,7 @@ print(f.vltypes['phony_vlen'])
 z = f.createDimension('z', 10)
 strvar = f.createVariable('strvar',str,'z')
 chars = '1234567890aabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
-data = numpy.empty(10,object)
+data = np.empty(10,object)
 for n in range(10):
     stringlen = random.randint(2,12)
     data[n] = ''.join([random.choice(chars) for i in range(stringlen)])
@@ -270,7 +270,7 @@ enum_dict = {u'Altocumulus': 7, u'Missing': 255, u'Stratus': 2, u'Clear': 0,
 u'Nimbostratus': 6, u'Cumulus': 4, u'Altostratus': 5, u'Cumulonimbus': 1,
 u'Stratocumulus': 3}
 # create the Enum type called 'cloud_t'.
-cloud_type = f.createEnumType(numpy.uint8,'cloud_t',enum_dict)
+cloud_type = f.createEnumType(np.uint8,'cloud_t',enum_dict)
 print(cloud_type)
 time = f.createDimension('time',None)
 # create a 1d variable of type 'cloud_type' called 'primary_clouds'.
@@ -295,7 +295,7 @@ nc = Dataset('stringtest.nc','w',format='NETCDF4_CLASSIC')
 nc.createDimension('nchars',3)
 nc.createDimension('nstrings',None)
 v = nc.createVariable('strings','S1',('nstrings','nchars'))
-datain = numpy.array(['foo','bar'],dtype='S3')
+datain = np.array(['foo','bar'],dtype='S3')
 v[:] = stringtochar(datain) # manual conversion to char array
 print(v[:]) # data returned as char array
 v._Encoding = 'ascii' # this enables automatic conversion
@@ -304,12 +304,12 @@ print(v[:]) # data returned in numpy string array
 nc.close()
 # strings in compound types
 nc = Dataset('compoundstring_example.nc','w')
-dtype = numpy.dtype([('observation', 'f4'),
-                     ('station_name','S12')])
+dtype = np.dtype([('observation', 'f4'),
+                  ('station_name','S12')])
 station_data_t = nc.createCompoundType(dtype,'station_data')
 nc.createDimension('station',None)
 statdat = nc.createVariable('station_obs', station_data_t, ('station',))
-data = numpy.empty(2,station_data_t.dtype_view)
+data = np.empty(2,station_data_t.dtype_view)
 data['observation'][:] = (123.,3.14)
 data['station_name'][:] = ('Boulder','New York')
 print(statdat.dtype) # strings actually stored as character arrays
@@ -325,8 +325,8 @@ nc.close()
 # to disk when it is closed.
 nc = Dataset('diskless_example.nc','w',diskless=True,persist=True)
 d = nc.createDimension('x',None)
-v = nc.createVariable('v',numpy.int32,'x')
-v[0:5] = numpy.arange(5)
+v = nc.createVariable('v',np.int32,'x')
+v[0:5] = np.arange(5)
 print(nc)
 print(nc['v'][:])
 nc.close() # file saved to disk
@@ -345,8 +345,8 @@ nc.close()
 # used if format is NETCDF3 (ignored for NETCDF4/HDF5 files).
 nc = Dataset('inmemory.nc', mode='w',memory=1028)
 d = nc.createDimension('x',None)
-v = nc.createVariable('v',numpy.int32,'x')
-v[0:5] = numpy.arange(5)
+v = nc.createVariable('v',np.int32,'x')
+v[0:5] = np.arange(5)
 nc_buf = nc.close() # close returns memoryview
 print(type(nc_buf))
 # save nc_buf to disk, read it back in and check.

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -487,9 +487,9 @@ Now that you have a netCDF [Variable](#Variable) instance, how do you put data
 into it? You can just treat it like an array and assign data to a slice.
 
 ```python
->>> import numpy
->>> lats =  numpy.arange(-90,91,2.5)
->>> lons =  numpy.arange(-180,180,2.5)
+>>> import numpy as np
+>>> lats =  np.arange(-90,91,2.5)
+>>> lons =  np.arange(-180,180,2.5)
 >>> latitudes[:] = lats
 >>> longitudes[:] = lons
 >>> print("latitudes =\\n{}".format(latitudes[:]))
@@ -648,7 +648,7 @@ datasets are not supported).
 ...     with Dataset("mftest%s.nc" % nf, "w", format="NETCDF4_CLASSIC") as f:
 ...         _ = f.createDimension("x",None)
 ...         x = f.createVariable("x","i",("x",))
-...         x[0:10] = numpy.arange(nf*10,10*(nf+1))
+...         x[0:10] = np.arange(nf*10,10*(nf+1))
 ```
 
 Now read all the files back in at once with [MFDataset](#MFDataset)
@@ -744,14 +744,14 @@ for storing numpy complex arrays.  Here's an example:
 >>> f = Dataset("complex.nc","w")
 >>> size = 3 # length of 1-d complex array
 >>> # create sample complex data.
->>> datac = numpy.exp(1j*(1.+numpy.linspace(0, numpy.pi, size)))
+>>> datac = np.exp(1j*(1.+np.linspace(0, np.pi, size)))
 >>> # create complex128 compound data type.
->>> complex128 = numpy.dtype([("real",numpy.float64),("imag",numpy.float64)])
+>>> complex128 = np.dtype([("real",np.float64),("imag",np.float64)])
 >>> complex128_t = f.createCompoundType(complex128,"complex128")
 >>> # create a variable with this data type, write some data to it.
 >>> x_dim = f.createDimension("x_dim",None)
 >>> v = f.createVariable("cmplx_var",complex128_t,"x_dim")
->>> data = numpy.empty(size,complex128) # numpy structured array
+>>> data = np.empty(size,complex128) # numpy structured array
 >>> data["real"] = datac.real; data["imag"] = datac.imag
 >>> v[:] = data # write numpy structured array to netcdf compound var
 >>> # close and reopen the file, check the contents.
@@ -759,7 +759,7 @@ for storing numpy complex arrays.  Here's an example:
 >>> v = f.variables["cmplx_var"]
 >>> datain = v[:] # read in all the data into a numpy structured array
 >>> # create an empty numpy complex array
->>> datac2 = numpy.empty(datain.shape,numpy.complex128)
+>>> datac2 = np.empty(datain.shape,np.complex128)
 >>> # .. fill it with contents of structured array.
 >>> datac2.real = datain["real"]; datac2.imag = datain["imag"]
 >>> print('{}: {}'.format(datac.dtype, datac)) # original data
@@ -805,7 +805,7 @@ method of a [Dataset](#Dataset) or [Group](#Group) instance.
 
 ```python
 >>> f = Dataset("tst_vlen.nc","w")
->>> vlen_t = f.createVLType(numpy.int32, "phony_vlen")
+>>> vlen_t = f.createVLType(np.int32, "phony_vlen")
 ```
 
 The numpy datatype of the variable-length sequences and the name of the
@@ -831,10 +831,10 @@ In this case, they contain 1-D numpy `int32` arrays of random length between
 ```python
 >>> import random
 >>> random.seed(54321)
->>> data = numpy.empty(len(y)*len(x),object)
+>>> data = np.empty(len(y)*len(x),object)
 >>> for n in range(len(y)*len(x)):
-...     data[n] = numpy.arange(random.randint(1,10),dtype="int32")+1
->>> data = numpy.reshape(data,(len(y),len(x)))
+...     data[n] = np.arange(random.randint(1,10),dtype="int32")+1
+>>> data = np.reshape(data,(len(y),len(x)))
 >>> vlvar[:] = data
 >>> print("vlen variable =\\n{}".format(vlvar[:]))
 vlen variable =
@@ -880,7 +880,7 @@ array is assigned to the vlen string variable.
 
 ```python
 >>> chars = "1234567890aabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
->>> data = numpy.empty(10,"O")
+>>> data = np.empty(10,"O")
 >>> for n in range(10):
 ...     stringlen = random.randint(2,12)
 ...     data[n] = "".join([random.choice(chars) for i in range(stringlen)])
@@ -926,7 +926,7 @@ values and their names are used to define an Enum data type using
 ... 'Nimbostratus': 6, 'Cumulus': 4, 'Altostratus': 5,
 ... 'Cumulonimbus': 1, 'Stratocumulus': 3}
 >>> # create the Enum type called 'cloud_t'.
->>> cloud_type = nc.createEnumType(numpy.uint8,'cloud_t',enum_dict)
+>>> cloud_type = nc.createEnumType(np.uint8,'cloud_t',enum_dict)
 >>> print(cloud_type)
 <class 'netCDF4._netCDF4.EnumType'>: name = 'cloud_t', numpy dtype = uint8, fields/values ={'Altocumulus': 7, 'Missing': 255, 'Stratus': 2, 'Clear': 0, 'Nimbostratus': 6, 'Cumulus': 4, 'Altostratus': 5, 'Cumulonimbus': 1, 'Stratocumulus': 3}
 ```
@@ -1065,7 +1065,7 @@ characters with one more dimension. For example,
 >>> _ = nc.createDimension('nchars',3)
 >>> _ = nc.createDimension('nstrings',None)
 >>> v = nc.createVariable('strings','S1',('nstrings','nchars'))
->>> datain = numpy.array(['foo','bar'],dtype='S3')
+>>> datain = np.array(['foo','bar'],dtype='S3')
 >>> v[:] = stringtochar(datain) # manual conversion to char array
 >>> print(v[:]) # data returned as char array
 [[b'f' b'o' b'o']
@@ -1095,12 +1095,12 @@ Here's an example:
 
 ```python
 >>> nc = Dataset('compoundstring_example.nc','w')
->>> dtype = numpy.dtype([('observation', 'f4'),
+>>> dtype = np.dtype([('observation', 'f4'),
 ...                      ('station_name','S10')])
 >>> station_data_t = nc.createCompoundType(dtype,'station_data')
 >>> _ = nc.createDimension('station',None)
 >>> statdat = nc.createVariable('station_obs', station_data_t, ('station',))
->>> data = numpy.empty(2,dtype)
+>>> data = np.empty(2,dtype)
 >>> data['observation'][:] = (123.,3.14)
 >>> data['station_name'][:] = ('Boulder','New York')
 >>> print(statdat.dtype) # strings actually stored as character arrays
@@ -1144,8 +1144,8 @@ approaches.
 >>> # and persist the file to disk when it is closed.
 >>> nc = Dataset('diskless_example.nc','w',diskless=True,persist=True)
 >>> d = nc.createDimension('x',None)
->>> v = nc.createVariable('v',numpy.int32,'x')
->>> v[0:5] = numpy.arange(5)
+>>> v = nc.createVariable('v',np.int32,'x')
+>>> v[0:5] = np.arange(5)
 >>> print(nc)
 <class 'netCDF4._netCDF4.Dataset'>
 root group (NETCDF4 data model, file format HDF5):
@@ -1178,8 +1178,8 @@ root group (NETCDF4 data model, file format HDF5):
 >>> # (ignored for NETCDF4/HDF5 files).
 >>> nc = Dataset('inmemory.nc', mode='w',memory=1028)
 >>> d = nc.createDimension('x',None)
->>> v = nc.createVariable('v',numpy.int32,'x')
->>> v[0:5] = numpy.arange(5)
+>>> v = nc.createVariable('v',np.int32,'x')
+>>> v[0:5] = np.arange(5)
 >>> nc_buf = nc.close() # close returns memoryview
 >>> print(type(nc_buf))
 <class 'memoryview'>
@@ -6589,7 +6589,7 @@ time unit and/or calendar to all files.
 Example usage (See [MFTime.__init__](#MFTime.__init__) for more details):
 
 ```python
->>> import numpy
+>>> import numpy as np
 >>> f1 = Dataset("mftest_1.nc","w", format="NETCDF4_CLASSIC")
 >>> f2 = Dataset("mftest_2.nc","w", format="NETCDF4_CLASSIC")
 >>> f1.createDimension("time",None)
@@ -6600,8 +6600,8 @@ Example usage (See [MFTime.__init__](#MFTime.__init__) for more details):
 >>> t2.units = "days since 2000-02-01"
 >>> t1.calendar = "standard"
 >>> t2.calendar = "standard"
->>> t1[:] = numpy.arange(31)
->>> t2[:] = numpy.arange(30)
+>>> t1[:] = np.arange(31)
+>>> t2[:] = np.arange(30)
 >>> f1.close()
 >>> f2.close()
 >>> # Read the two files in at once, in one Dataset.

--- a/test/tst_atts.py
+++ b/test/tst_atts.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 import warnings
 
-import numpy as NP
+import numpy as np
 from collections import OrderedDict
 from numpy.random.mtrand import uniform
 
@@ -26,7 +26,7 @@ STRATT = 'string attribute'
 EMPTYSTRATT = ''
 INTATT = 1
 FLOATATT = math.pi
-SEQATT = NP.arange(10)
+SEQATT = np.arange(10)
 STRINGSEQATT = ['mary ','','had ','a ','little ','lamb',]
 #ATTDICT = {'stratt':STRATT,'floatatt':FLOATATT,'seqatt':SEQATT,
 #           'stringseqatt':''.join(STRINGSEQATT), # changed in issue #770
@@ -106,8 +106,8 @@ class VariablesTestCase(unittest.TestCase):
             raise ValueError('This test should have failed.')
         # issue #485 (triggers segfault in C lib
         # with version 1.2.1 without pull request #486)
-        f.foo = NP.array('bar','S')
-        f.foo = NP.array('bar','U')
+        f.foo = np.array('bar','S')
+        f.foo = np.array('bar','U')
         # issue #529 write string attribute as NC_CHAR unless
         # it can't be decoded to ascii.  Add setncattr_string
         # method to force NC_STRING.
@@ -145,7 +145,7 @@ class VariablesTestCase(unittest.TestCase):
         # global attributes.
         # check __dict__ method for accessing all netCDF attributes.
         for key,val in ATTDICT.items():
-            if type(val) == NP.ndarray:
+            if type(val) == np.ndarray:
                 assert f.__dict__[key].tolist() == val.tolist()
             else:
                 assert f.__dict__[key] == val
@@ -162,7 +162,7 @@ class VariablesTestCase(unittest.TestCase):
         # variable attributes.
         # check __dict__ method for accessing all netCDF attributes.
         for key,val in ATTDICT.items():
-            if type(val) == NP.ndarray:
+            if type(val) == np.ndarray:
                 assert v.__dict__[key].tolist() == val.tolist()
             else:
                 assert v.__dict__[key] == val
@@ -202,7 +202,7 @@ class VariablesTestCase(unittest.TestCase):
         # check attributes in subgroup.
         # global attributes.
         for key,val in ATTDICT.items():
-            if type(val) == NP.ndarray:
+            if type(val) == np.ndarray:
                 assert g.__dict__[key].tolist() == val.tolist()
             else:
                 assert g.__dict__[key] == val
@@ -215,7 +215,7 @@ class VariablesTestCase(unittest.TestCase):
         assert g.stringseqatt == STRINGSEQATT
         assert g.stringseqatt_array == STRINGSEQATT
         for key,val in ATTDICT.items():
-            if type(val) == NP.ndarray:
+            if type(val) == np.ndarray:
                 assert v1.__dict__[key].tolist() == val.tolist()
             else:
                 assert v1.__dict__[key] == val

--- a/test/tst_dims.py
+++ b/test/tst_dims.py
@@ -2,7 +2,6 @@ import sys
 import unittest
 import os
 import tempfile
-import numpy as NP
 from numpy.random.mtrand import uniform
 import netCDF4
 

--- a/test/tst_grps.py
+++ b/test/tst_grps.py
@@ -2,7 +2,6 @@ import sys
 import unittest
 import os
 import tempfile
-import numpy as NP
 import netCDF4
 
 # test group creation.

--- a/test/tst_grps2.py
+++ b/test/tst_grps2.py
@@ -2,7 +2,6 @@ import sys
 import unittest
 import os
 import tempfile
-import numpy as NP
 import netCDF4
 
 # test implicit group creation by using unix-like paths

--- a/test/tst_masked.py
+++ b/test/tst_masked.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 import os
 import tempfile
-import numpy as NP
+import numpy as np
 from numpy import ma
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 from numpy.random.mtrand import uniform
@@ -19,22 +19,22 @@ ndim = 10
 ranarr = 100.*uniform(size=(ndim))
 ranarr2 = 100.*uniform(size=(ndim))
 # used for checking vector missing_values
-arr3 = NP.linspace(0,9,ndim)
-mask = NP.zeros(ndim,NP.bool_); mask[-1]=True; mask[-2]=True
-marr3 = NP.ma.array(arr3, mask=mask, dtype=NP.int32)
+arr3 = np.linspace(0,9,ndim)
+mask = np.zeros(ndim,np.bool_); mask[-1]=True; mask[-2]=True
+marr3 = np.ma.array(arr3, mask=mask, dtype=np.int32)
 packeddata = 10.*uniform(size=(ndim))
 missing_value = -9999.
-missing_value2 = NP.nan
+missing_value2 = np.nan
 missing_value3 = [8,9]
 ranarr[::2] = missing_value
 ranarr2[::2] = missing_value2
-NP.seterr(invalid='ignore') # silence warnings from ma.masked_values
+np.seterr(invalid='ignore') # silence warnings from ma.masked_values
 maskedarr = ma.masked_values(ranarr,missing_value)
 #maskedarr2 = ma.masked_values(ranarr2,missing_value2)
 maskedarr2 = ma.masked_invalid(ranarr2)
 scale_factor = (packeddata.max()-packeddata.min())/(2.*32766.)
 add_offset = 0.5*(packeddata.max()+packeddata.min())
-packeddata2 = NP.around((packeddata-add_offset)/scale_factor).astype('i2')
+packeddata2 = np.around((packeddata-add_offset)/scale_factor).astype('i2')
 
 class PrimitiveTypesTestCase(unittest.TestCase):
 
@@ -71,7 +71,7 @@ class PrimitiveTypesTestCase(unittest.TestCase):
         doh2[0] = 1.
         # added test for issue 515
         file.createDimension('x',1)
-        v = file.createVariable('v',NP.float64,'x',fill_value=-9999)
+        v = file.createVariable('v',np.float64,'x',fill_value=-9999)
         file.close()
 
         # issue #972: when auto_fill off byte arrays (u1,i1) should
@@ -119,18 +119,18 @@ class PrimitiveTypesTestCase(unittest.TestCase):
         assert_array_almost_equal(datamasked[:].filled(),ranarr)
         assert_array_almost_equal(datamasked2[:].filled(),ranarr2)
         assert_array_almost_equal(datapacked[:],packeddata,decimal=4)
-        assert(datapacked3[:].dtype == NP.float64)
+        assert(datapacked3[:].dtype == np.float64)
         # added to test fix to issue 46 (result before r865 was 10)
         assert_array_equal(datapacked2[0],11)
         # added test for issue 515
-        assert(file['v'][0] is NP.ma.masked)
+        assert(file['v'][0] is np.ma.masked)
         file.close()
         # issue 766
-        NP.seterr(invalid='raise')
+        np.seterr(invalid='raise')
         f = netCDF4.Dataset(self.file, 'w')
         f.createDimension('dimension', 2)
-        f.createVariable('variable', NP.float32, dimensions=('dimension',))
-        f['variable'][:] = NP.nan
+        f.createVariable('variable', np.float32, dimensions=('dimension',))
+        f['variable'][:] = np.nan
         data = f['variable'][:] # should not raise an error
         f.close()
         # issue #972

--- a/test/tst_rename.py
+++ b/test/tst_rename.py
@@ -2,7 +2,6 @@ import sys
 import unittest
 import os
 import tempfile
-import numpy as NP
 import netCDF4
 from netCDF4 import __has_rename_grp__
 

--- a/test/tst_scalarvar.py
+++ b/test/tst_scalarvar.py
@@ -2,7 +2,6 @@ import sys
 import unittest
 import os
 import tempfile
-import numpy as NP
 from numpy.testing import assert_almost_equal
 import netCDF4
 import math

--- a/test/tst_unlimdim.py
+++ b/test/tst_unlimdim.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 import os
 import tempfile
-import numpy as NP
+import numpy as np
 from numpy.random.mtrand import uniform
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import netCDF4
@@ -59,7 +59,7 @@ class UnlimdimTestCase(unittest.TestCase):
         self.assertTrue(bar.shape == (n1dim,n2dim,n3dim))
         # check data.
         #assert_array_almost_equal(bar[:,:,:], ranarr)
-        assert_array_almost_equal(bar[:,:,:], 2.*NP.ones((n1dim,n2dim,n3dim),ranarr.dtype))
+        assert_array_almost_equal(bar[:,:,:], 2.*np.ones((n1dim,n2dim,n3dim),ranarr.dtype))
         f.close()
 
 if __name__ == '__main__':

--- a/test/tst_vars.py
+++ b/test/tst_vars.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 import os
 import tempfile
-import numpy as NP
+import numpy as np
 from numpy.random.mtrand import uniform
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import netCDF4
@@ -67,7 +67,7 @@ class VariablesTestCase(unittest.TestCase):
         assert v1.size == DIM1_LEN * DIM2_LEN * DIM3_LEN
         assert len(v1) == DIM1_LEN
 
-        #assert NP.allclose(v1[:],randomdata)
+        #assert np.allclose(v1[:],randomdata)
         assert_array_almost_equal(v1[:],randomdata)
         # check variables in sub group.
         g = f.groups[GROUP_NAME]
@@ -86,7 +86,7 @@ class VariablesTestCase(unittest.TestCase):
         assert v2.dimensions == (DIM2_NAME,DIM3_NAME)
         assert v1.shape == (DIM1_LEN,DIM2_LEN,DIM3_LEN)
         assert v2.shape == (DIM2_LEN,DIM3_LEN)
-        #assert NP.allclose(v1[:],randomdata)
+        #assert np.allclose(v1[:],randomdata)
         assert_array_almost_equal(v1[:],randomdata)
         f.close()
 


### PR DESCRIPTION
This PR is stylistic, to prefer `import numpy as np` convention over other styles:

- `import numpy as NP` was used in a few places, but this style has gone out of fashion since numpy early days.
- `import numpy` was changed in the tutorial and examples, but kept for the functional code of _netCDF4.pyx