### PR TITLE
Conda Installation code

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -482,7 +482,7 @@ types) are not supported.</p>
 
 <ul>
 <li>the easiest way to get going is to install via <code>pip install netCDF4</code>.
-(or if you use the <a href="http://conda.io">conda</a> package manager <code>conda install -c conda_forge netCDF4</code>).</li>
+(or if you use the <a href="http://conda.io">conda</a> package manager <code>conda install -c conda-forge netCDF4</code>).</li>
 </ul>
 
 <h2 id="developer-install">Developer Install</h2>


### PR DESCRIPTION
Under the Quick Install section, I think the command for Conda installation should rather be Conda install -c conda-forge netCDF4 instead of using an underscore between “conda” and “forge”.