### PR TITLE
MAINT: Python3 classes do not need to inherit from object

### DIFF
--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -6386,7 +6386,7 @@ Example usage (See `MFDataset.__init__` for more details):
         # raise error is user tries to pickle a MFDataset object.
         raise NotImplementedError('MFDataset is not picklable')
 
-class _Dimension(object):
+class _Dimension:
     def __init__(self, dimname, dim, dimlens, dimtotlen):
         self.dimlens = dimlens
         self.dimtotlen = dimtotlen
@@ -6403,7 +6403,7 @@ class _Dimension(object):
             return "%r: name = '%s', size = %s" %\
                 (type(self), self._name, len(self))
 
-class _Variable(object):
+class _Variable:
     def __init__(self, dset, varname, var, recdimname):
         self.dimensions = var.dimensions
         self._dset = dset

--- a/test/tst_utils.py
+++ b/test/tst_utils.py
@@ -320,7 +320,7 @@ class TestsetStartCountStride(unittest.TestCase):
             #assert_equal(str(e), "At most one ellipsis allowed in a slicing expression")
             assert_equal(str(e), "list index out of range")
 
-class FakeGroup(object):
+class FakeGroup:
     """Create a fake group instance by passing a dictionary of booleans
     keyed by dimension name."""
     def __init__(self, dimensions):
@@ -328,7 +328,7 @@ class FakeGroup(object):
         for k,v in dimensions.items():
             self.dimensions[k] = FakeDimension(v)
 
-class FakeDimension(object):
+class FakeDimension:
     def __init__(self, unlimited=False):
         self.unlimited = unlimited
 


### PR DESCRIPTION
See this [Q/A](https://stackoverflow.com/questions/4015417/why-do-python-classes-inherit-object) for a background on `class Foo(object):` vs `class Foo:`.

In summary, only Python 2 required inheriting from `object`, but this is no longer necessary with Python 3.