### PR TITLE
MAINT: use 'yield from <expr>' to walk tree

### DIFF
--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -16,11 +16,10 @@ fcstgrp2 = rootgrp.createGroup('/forecasts/model2')
 
 # walk the group tree using a Python generator.
 def walktree(top):
-    values = top.groups.values()
-    yield values
+    yield top.groups.values()
     for value in top.groups.values():
-        for children in walktree(value):
-            yield  children
+        yield from walktree(value)
+
 print(rootgrp)
 for children in walktree(rootgrp):
     for child in children:

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -184,11 +184,9 @@ object yields summary information about it's contents.
 
 ```python
 >>> def walktree(top):
-...     values = top.groups.values()
-...     yield values
+...     yield top.groups.values()
 ...     for value in top.groups.values():
-...         for children in walktree(value):
-...             yield children
+...         yield from walktree(value)
 >>> print(rootgrp)
 <class 'netCDF4._netCDF4.Dataset'>
 root group (NETCDF4 data model, file format HDF5):

--- a/src/netCDF4/utils.py
+++ b/src/netCDF4/utils.py
@@ -58,11 +58,9 @@ def _walk_grps(topgrp):
     """Iterate through all (sub-) groups of topgrp, similar to os.walktree.
 
     """
-    grps = topgrp.groups.values()
-    yield grps
+    yield topgrp.groups.values()
     for grp in topgrp.groups.values():
-        for children in _walk_grps(grp):
-            yield children
+        yield from _walk_grps(grp)
 
 def _quantize(data,least_significant_digit):
     """

--- a/test/tst_grps.py
+++ b/test/tst_grps.py
@@ -30,11 +30,9 @@ TREE2.sort()
 
 # python generator to walk the Group tree.
 def walktree(top):
-    values = top.groups.values()
-    yield values
+    yield top.groups.values()
     for value in top.groups.values():
-        for children in walktree(value):
-            yield  children
+        yield from walktree(value)
 
 class GroupsTestCase(unittest.TestCase):
 


### PR DESCRIPTION
This PR uses simple cases of [PEP 380](https://www.python.org/dev/peps/pep-0380/) to rewrite (e.g.):
```python
for children in walktree(value):
    yield children
```
into:
```python
yield from walktree(value)
```
which was a new feature in [Python 3.3](https://docs.python.org/3/whatsnew/3.3.html#pep-380), but raised a `SyntaxError` in prior releases.