### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Fixes bug in implementation of NETCDF4_CLASSIC parallel IO support in 1.4.3.
 10/26/2018: Version [1.4.2](https://pypi.python.org/pypi/netCDF4/1.4.2) released. Minor bugfixes, added `Variable.get_dims()` method and `master_file` kwarg for `MFDataset.__init__`.
 
 08/10/2018: Version [1.4.1](https://pypi.python.org/pypi/netCDF4/1.4.1) released. The old slicing behavior
-(numpy array returned unless missing values are present, otherwise masked array returned) is renabled
+(numpy array returned unless missing values are present, otherwise masked array returned) is re-enabled
 via `set_always_mask(False)`.
 
 05/11/2018: Version [1.4.0](https://pypi.python.org/pypi/netCDF4/1.4.0) released. The netcdftime package is no longer

--- a/README.wheels.md
+++ b/README.wheels.md
@@ -28,7 +28,7 @@ dynamic libraries apart from those provided as standard by OSX.
 
 ### Triggering a build
 
-You will need write permision to the github repository to trigger new builds
+You will need write permission to the github repository to trigger new builds
 on the travis-ci interface.  Contact us on the mailing list if you need this.
 
 You can trigger a build by:

--- a/examples/subset.py
+++ b/examples/subset.py
@@ -3,7 +3,7 @@ import netCDF4
 import numpy as np
 import matplotlib.pyplot as plt
 
-# use real data from CFS reanlysis.
+# use real data from CFS reanalysis.
 # note:  we're reading GRIB2 data!
 URL="http://nomads.ncdc.noaa.gov/thredds/dodsC/modeldata/cmd_flxf/2010/201007/20100701/flxf00.gdas.2010070100.grb2"
 nc = netCDF4.Dataset(URL)

--- a/src/netCDF4/utils.py
+++ b/src/netCDF4/utils.py
@@ -235,7 +235,7 @@ def _StartCountStride(elem, shape, dimensions=None, grp=None, datashape=None,\
             unlim = False
         # convert boolean index to integer array.
         if np.iterable(ea) and ea.dtype.kind =='b':
-            # check that boolen array not too long
+            # check that boolean array not too long
             if not unlim and shape[i] != len(ea):
                 msg="""
 Boolean array must have the same shape as the data along this dimension."""
@@ -539,7 +539,7 @@ def ncinfo():
             sys.stderr.write(usage)
             sys.exit(0)
 
-    # filename passed as last argumenbt
+    # filename passed as last argument
     try:
         filename = pargs[-1]
     except IndexError:

--- a/test/tst_Unsigned.py
+++ b/test/tst_Unsigned.py
@@ -10,7 +10,7 @@ class Test_Unsigned(unittest.TestCase):
     integer data stored with a signed integer type in netcdf-3.
     If _Unsigned=True, a view to the data as unsigned integers is returned.
     set_autoscale can be used to turn this off (default is on)
-    See issue #656 (pull reqeust #658).
+    See issue #656 (pull request #658).
     """
     def test_unsigned(self):
         f = netCDF4.Dataset("ubyte.nc")

--- a/test/tst_atts.py
+++ b/test/tst_atts.py
@@ -43,7 +43,7 @@ class VariablesTestCase(unittest.TestCase):
         f = netCDF4.Dataset(self.file,'w')
         # try to set a dataset attribute with one of the reserved names.
         f.setncattr('file_format','netcdf4_format')
-        # test attribute renameing
+        # test attribute renaming
         f.stratt_tmp = STRATT
         f.renameAttribute('stratt_tmp','stratt')
         f.emptystratt = EMPTYSTRATT

--- a/test/tst_fancyslicing.py
+++ b/test/tst_fancyslicing.py
@@ -56,7 +56,7 @@ class VariablesTestCase(unittest.TestCase):
         # integer array slice.
         v[:,i,:] = -100
         self.data[:,i,:] = -100
-        # boolen array slice.
+        # boolean array slice.
         v[ib2] = -200
         self.data[ib2] = -200
         v[ib3,:,:] = -300

--- a/test/tst_masked4.py
+++ b/test/tst_masked4.py
@@ -96,7 +96,7 @@ class SetValidMinMax(unittest.TestCase):
         self.assertTrue(np.all(self.v_ma.mask == v.mask))
         self.assertTrue(np.all(self.v_ma.mask == v2.mask))
         # treating _FillValue as valid_min/valid_max was
-        # too suprising, revert to old behaviour (issue #761)
+        # too surprising, revert to old behaviour (issue #761)
         #self.assertTrue(np.all(self.v_ma.mask == v3.mask))
         # check that underlying data is same as in netcdf file
         v = f.variables['v']

--- a/test/tst_shape.py
+++ b/test/tst_shape.py
@@ -24,7 +24,7 @@ class ShapeTestCase(unittest.TestCase):
 
     def runTest(self):
         """test for issue 90 (array shape should not be modified by
-        assigment to netCDF variable)"""
+        assignment to netCDF variable)"""
         f  = Dataset(self.file, 'a')
         v = f.variables['data']
         v[0] = data


### PR DESCRIPTION
There are small typos in:
- README.md
- README.wheels.md
- examples/subset.py
- src/netCDF4/utils.py
- test/tst_Unsigned.py
- test/tst_atts.py
- test/tst_fancyslicing.py
- test/tst_masked4.py
- test/tst_shape.py

Fixes:
- Should read `boolean` rather than `boolen`.
- Should read `surprising` rather than `suprising`.
- Should read `request` rather than `reqeust`.
- Should read `renaming` rather than `renameing`.
- Should read `reanalysis` rather than `reanlysis`.
- Should read `re-enabled` rather than `renabled`.
- Should read `permission` rather than `permision`.
- Should read `assignment` rather than `assigment`.
- Should read `argument` rather than `argumenbt`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md