### PR TITLE
Trivial fix to `isopen` docstring via Cython source

### DIFF
--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -2468,9 +2468,9 @@ Close the Dataset.
 
     def isopen(self):
         """
-**`close(self)`**
+**`isopen(self)`**
 
-is the Dataset open or closed?
+Is the Dataset open or closed?
         """
         return bool(self._isopen)
 


### PR DESCRIPTION
Hi, whilst using the documentation today I noticed that there was a mistake (presumably a copy-and-paste one) whereby the docstring of `isopen` gives the signature of the method documented directly above it, as shown on the [live build of the API reference](https://unidata.github.io/netcdf4-python/#Dataset.isopen).

Since it was just as quick to fix as to report (I can't see anything related to this on the Issue Tracker), I thought I'd put up this PR which amends the docstring in the Cython source, which seems the sensible approach to updating the docs given the steps outlined in the `create_docs.sh` script. (Also I couldn't resist capitalising the initial letter of the following sentence to be consistent with the other docstrings whilst I was there.)

(Let me know if any amendments are required and I will change it.) Thanks.