### PR TITLE
Use assertRaisesRegex instead of assertRaisesRegexp for Python 3.11 compatibility.

### DIFF
--- a/test/tst_filepath.py
+++ b/test/tst_filepath.py
@@ -26,7 +26,7 @@ class test_filepath(unittest.TestCase):
 
     def test_no_such_file_raises(self):
         fname = 'not_a_nc_file.nc'
-        with self.assertRaisesRegexp(IOError, fname):
+        with self.assertRaisesRegex(IOError, fname):
             netCDF4.Dataset(fname, 'r')
 
 


### PR DESCRIPTION
The deprecated aliases were removed in Python 3.11 in python/cpython#28268 .