### PR TITLE
add support for quantization/bit-grooming in netcdf-c 4.8.2

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -55,6 +55,9 @@ jobs:
       run: |
         export PATH=${NETCDF_DIR}/bin:${PATH} 
         python checkversion.py
+        cd examples
+        python bench_compress4.py
+        cd ..
         # serial
         cd test
         python run_all.py

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -1,0 +1,76 @@
+name: Build and Test on Linux with netcdf-c github master
+on: [push, pull_request]
+jobs:
+  build-linux:
+    name: Python (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    env:
+      NETCDF_DIR: ${{ github.workspace }}/..
+      CC: mpicc.mpich
+      #NO_NET: 1
+    strategy:
+      matrix:
+        python-version: ["3.9"]
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Ubuntu Dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install mpich libmpich-dev libhdf5-mpich-dev libcurl4-openssl-dev 
+        echo "Download and build netCDF github master"
+        git clone https://github.com/Unidata/netcdf-c
+        pushd netcdf-c
+        export CPPFLAGS="-I/usr/include/hdf5/mpich -I${NETCDF_DIR}/include"
+        export LDFLAGS="-L${NETCDF_DIR}/lib"
+        export LIBS="-lhdf5_mpich_hl -lhdf5_mpich -lm -lz"
+        autoreconf -i
+        ./configure --prefix $NETCDF_DIR --enable-netcdf-4 --enable-shared --enable-dap --enable-parallel4 
+        make -j 2
+        make install
+        popd
+
+#   - name: The job has failed
+#     if: ${{ failure() }}
+#     run: |
+#       cd netcdf-c-${NETCDF_VERSION}
+#       cat config.log 
+
+    - name: Install python dependencies via pip
+      run: |
+        python -m pip install --upgrade pip
+        pip install numpy cython cftime pytest twine wheel check-manifest mpi4py
+
+    - name: Install netcdf4-python
+      run: |
+        export PATH=${NETCDF_DIR}/bin:${PATH} 
+        python setup.py install
+    - name: Test
+      run: |
+        export PATH=${NETCDF_DIR}/bin:${PATH} 
+        python checkversion.py
+        # serial
+        cd test
+        python run_all.py
+        # parallel
+        cd ../examples
+        mpirun.mpich -np 4 python mpi_example.py
+        if [ $? -ne 0 ] ; then
+          echo "hdf5 mpi test failed!"
+          exit 1
+        else
+          echo "hdf5 mpi test passed!"
+        fi
+        mpirun.mpich -np 4 python mpi_example_compressed.py
+        if [ $? -ne 0 ] ; then
+          echo "hdf5 compressed mpi test failed!"
+          exit 1
+        else
+          echo "hdf5 compressed mpi test passed!"
+        fi

--- a/Changelog
+++ b/Changelog
@@ -1,7 +1,8 @@
  version 1.6.0 (not yet released)
 =================================
- * add support for new bit-grooming/quantization functions in netcdf-c 4.8.2.  netCDF4.Dataset.createVariable API
-   has changed - lsd ("least significant digit") keyword changed to nsd (number of significant digits).
+ * add support for new bit-grooming/quantization functions in netcdf-c 4.8.2 via "signficant_digits"
+   kwarg in Dataset.createVariable. "signficant_digits" Dataset method returns value associated with
+   Variable.
 
  version 1.5.8 (tag v1.5.8rel)
 ==============================

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,8 @@
+ version 1.6.0 (not yet released)
+=================================
+ * add support for new bit-grooming/quantization functions in netcdf-c 4.8.2.  netCDF4.Dataset.createVariable API
+   has changed - lsd ("least significant digit") keyword changed to nsd (number of significant digits).
+
  version 1.5.8 (tag v1.5.8rel)
 ==============================
  * Fix Enum bug (issue #1128): the enum_dict member of an EnumType read from a file

--- a/Changelog
+++ b/Changelog
@@ -2,7 +2,8 @@
 =================================
  * add support for new bit-grooming/quantization functions in netcdf-c 4.8.2 via "signficant_digits"
    kwarg in Dataset.createVariable. "signficant_digits" Dataset method returns value associated with
-   Variable.
+   Variable. If significant_digits < 0, alterate quantization method used
+   ("granular bit grooming").
  * opening a Dataset in append mode (mode = 'a' or 'r+') creates a Dataset
    if one does not already exist (similar to python open builtin).  Issue #1144.
    Added a mode='x' option (as in python open) which is the same as mode='w' with

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ include test/*py
 include test/*nc
 include src/netCDF4/__init__.py
 include src/netCDF4/_netCDF4.pyx
+exclude src/netCDF4/_netCDF4.c
 include src/netCDF4/utils.py
 include include/netCDF4.pxi
 include include/mpi-compat.h

--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@
 
                     <h2>Contents</h2>
                     <ul>
-  <li><a href="#version-158">Version 1.5.8</a></li>
+  <li><a href="#version-160">Version 1.6.0</a></li>
 </ul></li>
 <li><a href="#introduction">Introduction</a>
 <ul>
@@ -221,6 +221,9 @@
                         </li>
                         <li>
                                 <a class="function" href="#Variable.filters">filters</a>
+                        </li>
+                        <li>
+                                <a class="function" href="#Variable.significant_digits">significant_digits</a>
                         </li>
                         <li>
                                 <a class="function" href="#Variable.endian">endian</a>
@@ -456,7 +459,7 @@
                     <h1 class="modulename">
 netCDF4    </h1>
 
-                        <div class="docstring"><h2 id="version-158">Version 1.5.8</h2>
+                        <div class="docstring"><h2 id="version-160">Version 1.6.0</h2>
 
 <h1 id="introduction">Introduction</h1>
 
@@ -1098,14 +1101,23 @@ format is <code>NETCDF3_CLASSIC</code>, <code>NETCDF3_64BIT_OFFSET</code> or <co
 <p>If your data only has a certain number of digits of precision (say for
 example, it is temperature data that was measured with a precision of
 0.1 degrees), you can dramatically improve zlib compression by
-quantizing (or truncating) the data using the <code>least_significant_digit</code>
-keyword argument to <code><a href="#Dataset.createVariable">Dataset.createVariable</a></code>. The least
-significant digit is the power of ten of the smallest decimal place in
+quantizing (or truncating) the data. There are two methods supplied for
+doing this.  You can use the <code>least_significant_digit</code>
+keyword argument to <code><a href="#Dataset.createVariable">Dataset.createVariable</a></code> to specify
+the power of ten of the smallest decimal place in
 the data that is a reliable value. For example if the data has a
 precision of 0.1, then setting <code>least_significant_digit=1</code> will cause
 data the data to be quantized using <code>numpy.around(scale*data)/scale</code>, where
 scale = 2**bits, and bits is determined so that a precision of 0.1 is
-retained (in this case bits=4).  Effectively, this makes the compression
+retained (in this case bits=4).  This is done at the python level and is
+not a part of the underlying C library.  Starting with netcdf-c version 4.8.2,
+a quantization capability is provided in the library.  This can be
+used via the <code>significant_digits</code> <code><a href="#Dataset.createVariable">Dataset.createVariable</a></code> kwarg (new in
+version 1.6.0).
+The interpretation of <code>significant_digits</code> is different than <code>least_signficant_digit</code>
+in that it specifies the absolute number of significant digits independent
+of the magnitude of the variable (the floating point exponent).
+Either of these approaches makes the compression
 'lossy' instead of 'lossless', that is some precision in the data is
 sacrificed for the sake of disk space.</p>
 
@@ -1122,6 +1134,11 @@ sacrificed for the sake of disk space.</p>
 <p>and then</p>
 
 <div class="codehilite"><pre><span></span><code><span class="o">&gt;&gt;&gt;</span> <span class="n">temp</span> <span class="o">=</span> <span class="n">rootgrp</span><span class="o">.</span><span class="n">createVariable</span><span class="p">(</span><span class="s2">&quot;temp&quot;</span><span class="p">,</span><span class="s2">&quot;f4&quot;</span><span class="p">,(</span><span class="s2">&quot;time&quot;</span><span class="p">,</span><span class="s2">&quot;level&quot;</span><span class="p">,</span><span class="s2">&quot;lat&quot;</span><span class="p">,</span><span class="s2">&quot;lon&quot;</span><span class="p">,),</span><span class="n">zlib</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span><span class="n">least_significant_digit</span><span class="o">=</span><span class="mi">3</span><span class="p">)</span>
+</code></pre></div>
+
+<p>or with netcdf-c &gt;= 4.8.2</p>
+
+<div class="codehilite"><pre><span></span><code><span class="o">&gt;&gt;&gt;</span> <span class="n">temp</span> <span class="o">=</span> <span class="n">rootgrp</span><span class="o">.</span><span class="n">createVariable</span><span class="p">(</span><span class="s2">&quot;temp&quot;</span><span class="p">,</span><span class="s2">&quot;f4&quot;</span><span class="p">,(</span><span class="s2">&quot;time&quot;</span><span class="p">,</span><span class="s2">&quot;level&quot;</span><span class="p">,</span><span class="s2">&quot;lat&quot;</span><span class="p">,</span><span class="s2">&quot;lon&quot;</span><span class="p">,),</span><span class="n">zlib</span><span class="o">=</span><span class="kc">True</span><span class="p">,</span><span class="n">significant_digits</span><span class="o">=</span><span class="mi">4</span><span class="p">)</span>
 </code></pre></div>
 
 <p>and see how much smaller the resulting files are.</p>
@@ -1595,7 +1612,7 @@ approaches.</p>
 the parallel IO example, which is in <code>examples/mpi_example.py</code>.
 Unit tests are in the <code>test</code> directory.</p>
 
-<p><strong>contact</strong>: Jeffrey Whitaker <a href="&#109;&#97;&#105;&#108;&#116;&#x6f;&#x3a;&#x6a;&#101;f&#102;&#x72;&#x65;&#x79;&#x2e;&#115;&#x2e;&#119;&#104;&#x69;&#116;&#97;&#x6b;&#x65;&#x72;&#x40;&#110;&#111;&#97;&#x61;&#x2e;&#x67;&#x6f;&#x76;">&#x6a;&#101;f&#102;&#x72;&#x65;&#x79;&#x2e;&#115;&#x2e;&#119;&#104;&#x69;&#116;&#97;&#x6b;&#x65;&#x72;&#x40;&#110;&#111;&#97;&#x61;&#x2e;&#x67;&#x6f;&#x76;</a></p>
+<p><strong>contact</strong>: Jeffrey Whitaker <a href="&#x6d;&#97;&#x69;&#108;&#116;&#111;&#58;&#x6a;&#x65;&#x66;&#x66;&#114;ey&#46;&#115;&#x2e;&#x77;&#x68;i&#116;&#97;&#x6b;&#101;&#x72;&#x40;&#x6e;&#x6f;a&#x61;.&#x67;&#111;&#x76;">&#x6a;&#x65;&#x66;&#x66;&#114;ey&#46;&#115;&#x2e;&#x77;&#x68;i&#116;&#97;&#x6b;&#101;&#x72;&#x40;&#x6e;&#x6f;a&#x61;.&#x67;&#111;&#x76;</a></p>
 
 <p><strong>copyright</strong>: 2008 by Jeffrey Whitaker.</p>
 
@@ -1617,7 +1634,7 @@ Unit tests are in the <code>test</code> directory.</p>
                        <span class="n">__has_rename_grp__</span><span class="p">,</span> <span class="n">__has_nc_inq_path__</span><span class="p">,</span>
                        <span class="n">__has_nc_inq_format_extended__</span><span class="p">,</span> <span class="n">__has_nc_open_mem__</span><span class="p">,</span>
                        <span class="n">__has_nc_create_mem__</span><span class="p">,</span> <span class="n">__has_cdf5_format__</span><span class="p">,</span>
-                       <span class="n">__has_parallel4_support__</span><span class="p">,</span> <span class="n">__has_pnetcdf_support__</span><span class="p">)</span>
+                       <span class="n">__has_parallel4_support__</span><span class="p">,</span> <span class="n">__has_pnetcdf_support__</span><span class="p">,</span><span class="n">__has_quantization_support__</span><span class="p">)</span>
 <span class="n">__all__</span> <span class="o">=</span>\
 <span class="p">[</span><span class="s1">&#39;Dataset&#39;</span><span class="p">,</span><span class="s1">&#39;Variable&#39;</span><span class="p">,</span><span class="s1">&#39;Dimension&#39;</span><span class="p">,</span><span class="s1">&#39;Group&#39;</span><span class="p">,</span><span class="s1">&#39;MFDataset&#39;</span><span class="p">,</span><span class="s1">&#39;MFTime&#39;</span><span class="p">,</span><span class="s1">&#39;CompoundType&#39;</span><span class="p">,</span><span class="s1">&#39;VLType&#39;</span><span class="p">,</span><span class="s1">&#39;date2num&#39;</span><span class="p">,</span><span class="s1">&#39;num2date&#39;</span><span class="p">,</span><span class="s1">&#39;date2index&#39;</span><span class="p">,</span><span class="s1">&#39;stringtochar&#39;</span><span class="p">,</span><span class="s1">&#39;chartostring&#39;</span><span class="p">,</span><span class="s1">&#39;stringtoarr&#39;</span><span class="p">,</span><span class="s1">&#39;getlibversion&#39;</span><span class="p">,</span><span class="s1">&#39;EnumType&#39;</span><span class="p">,</span><span class="s1">&#39;get_chunk_cache&#39;</span><span class="p">,</span><span class="s1">&#39;set_chunk_cache&#39;</span><span class="p">]</span>
 </pre></div>
@@ -2035,7 +2052,7 @@ datatype.</p>
         
             <div class="docstring"><p><strong><code>createVariable(self, varname, datatype, dimensions=(), zlib=False,
 complevel=4, shuffle=True, fletcher32=False, contiguous=False, chunksizes=None,
-endian='native', least_significant_digit=None, fill_value=None, chunk_cache=None)</code></strong></p>
+endian='native', least_significant_digit=None, significant_digits=None, fill_value=None, chunk_cache=None)</code></strong></p>
 
 <p>Creates a new variable with the given <code>varname</code>, <code>datatype</code>, and
 <code><a href="#Dataset.dimensions">dimensions</a></code>. If dimensions are not given, the variable is assumed to be
@@ -2112,7 +2129,7 @@ netCDF <code>_FillValue</code> (the value that the variable gets filled with bef
 any data is written to it, defaults given in the dict <code><a href="#default_fillvals">netCDF4.default_fillvals</a></code>).
 If fill_value is set to <code>False</code>, then the variable is not pre-filled.</p>
 
-<p>If the optional keyword parameter <code>least_significant_digit</code> is
+<p>If the optional keyword parameters <code>least_significant_digit</code> or <code>significant_digits</code> are
 specified, variable data will be truncated (quantized). In conjunction
 with <code>zlib=True</code> this produces 'lossy', but significantly more
 efficient compression. For example, if <code>least_significant_digit=1</code>,
@@ -2122,7 +2139,10 @@ retained (in this case bits=4). From the
 <a href="http://www.esrl.noaa.gov/psl/data/gridded/conventions/cdc_netcdf_standard.shtml">PSL metadata conventions</a>:
 "least_significant_digit -- power of ten of the smallest decimal place
 in unpacked data that is a reliable value." Default is <code>None</code>, or no
-quantization, or 'lossless' compression.</p>
+quantization, or 'lossless' compression.  If <code>significant_digits=3</code>
+then the data will be quantized so that three significant digits are retained, independent
+of the floating point exponent. This option is available only with netcdf-c &gt;= 4.8.2, and 
+only works with <code>NETCDF4</code> or <code>NETCDF4_CLASSIC</code> formatted files.</p>
 
 <p>When creating variables in a <code>NETCDF4</code> or <code>NETCDF4_CLASSIC</code> formatted file,
 HDF5 creates something called a 'chunk cache' for each variable.  The
@@ -2156,7 +2176,7 @@ string containing the name of the Variable instance.
 The <code>least_significant_digit</code>
 attributes describes the power of ten of the smallest decimal place in
 the data the contains a reliable value.  assigned to the <code><a href="#Variable">Variable</a></code>
-instance. If <code>None</code>, the data is not truncated. The <code>ndim</code> attribute
+instance. The <code>ndim</code> attribute
 is the number of variable dimensions.</p>
 </div>
 
@@ -2761,6 +2781,14 @@ smallest decimal place in the data the contains a reliable value.  Data is
 truncated to this decimal place when it is assigned to the <code><a href="#Variable">Variable</a></code>
 instance. If <code>None</code>, the data is not truncated.</p>
 
+<p><strong><code><a href="#Variable.significant_digits">significant_digits</a></code></strong>: New in version 1.6.0. Describes the number of significant digits
+in the data the contains a reliable value.  Data is
+truncated to retain this number of significant digits when it is assigned to the <code><a href="#Variable">Variable</a></code>
+instance. If <code>None</code>, the data is not truncated. Only available with netcdf-c &gt;= 4.8.2,
+and only works with <code>NETCDF4</code> or <code>NETCDF4_CLASSIC</code> formatted files.
+The number of significant digits used in the quantization of variable data can be
+obtained using the <code><a href="#Variable.significant_digits">Variable.significant_digits</a></code> method.</p>
+
 <p><strong><code>__orthogonal_indexing__</code></strong>: Always <code>True</code>.  Indicates to client code
 that the object supports 'orthogonal indexing', which means that slices
 that are 1d arrays or lists slice along each dimension independently.  This
@@ -2858,13 +2886,19 @@ For netCDF 3 files (that don't use HDF5), only <code>endian='native'</code> is a
 <p>The <code>zlib, complevel, shuffle, fletcher32, contiguous</code> and <code>chunksizes</code>
 keywords are silently ignored for netCDF 3 files that do not use HDF5.</p>
 
-<p><strong><code>least_significant_digit</code></strong>: If specified, variable data will be
-truncated (quantized). In conjunction with <code>zlib=True</code> this produces
+<p><strong><code>least_significant_digit</code></strong>: If this or <code><a href="#Variable.significant_digits">significant_digits</a></code> are specified, 
+variable data will be truncated (quantized). <br />
+In conjunction with <code>zlib=True</code> this produces
 'lossy', but significantly more efficient compression. For example, if
 <code>least_significant_digit=1</code>, data will be quantized using
 around(scale<em>data)/scale, where scale = 2</em>*bits, and bits is determined
 so that a precision of 0.1 is retained (in this case bits=4). Default is
 <code>None</code>, or no quantization.</p>
+
+<p><strong><code><a href="#Variable.significant_digits">significant_digits</a></code></strong>: New in version 1.6.0. 
+As described for <code>least_significant_digit</code>
+except the number of significant digits retained is prescribed independent
+of the floating point exponent.  Only available with netcdf-c &gt;= 4.8.2.</p>
 
 <p><strong><code>fill_value</code></strong>:  If specified, the default netCDF <code>_FillValue</code> (the
 value that the variable gets filled with before any data is written to it)
@@ -3022,6 +3056,22 @@ attributes.</p>
             <div class="docstring"><p><strong><code>filters(self)</code></strong></p>
 
 <p>return dictionary containing HDF5 filter parameters.</p>
+</div>
+
+
+                            </div>
+                            <div id="Variable.significant_digits" class="classattr">
+                                        <div class="attr function"><a class="headerlink" href="#Variable.significant_digits">#&nbsp;&nbsp</a>
+
+        
+            <span class="def">def</span>
+            <span class="name">significant_digits</span><span class="signature">(unknown)</span>:
+    </div>
+
+        
+            <div class="docstring"><p><strong><code>significant_digits(self)</code></strong></p>
+
+<p>return number of significant digits used in quantization</p>
 </div>
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1612,7 +1612,7 @@ approaches.</p>
 the parallel IO example, which is in <code>examples/mpi_example.py</code>.
 Unit tests are in the <code>test</code> directory.</p>
 
-<p><strong>contact</strong>: Jeffrey Whitaker <a href="&#109;&#97;&#x69;&#108;&#116;&#x6f;&#58;&#x6a;&#101;&#x66;&#102;&#114;&#101;&#121;&#x2e;&#x73;&#46;wh&#x69;&#116;&#x61;&#x6b;&#101;&#x72;&#64;&#110;&#111;&#97;&#x61;&#x2e;&#103;&#x6f;&#118;">&#x6a;&#101;&#x66;&#102;&#114;&#101;&#121;&#x2e;&#x73;&#46;wh&#x69;&#116;&#x61;&#x6b;&#101;&#x72;&#64;&#110;&#111;&#97;&#x61;&#x2e;&#103;&#x6f;&#118;</a></p>
+<p><strong>contact</strong>: Jeffrey Whitaker <a href="&#109;&#97;&#105;&#x6c;&#116;o&#x3a;&#106;&#101;&#102;&#102;&#x72;&#x65;&#x79;&#x2e;&#x73;&#x2e;&#x77;&#104;&#x69;&#116;&#x61;&#107;&#x65;&#x72;&#x40;&#x6e;&#111;&#x61;&#x61;&#x2e;&#103;&#111;&#x76;">&#106;&#101;&#102;&#102;&#x72;&#x65;&#x79;&#x2e;&#x73;&#x2e;&#x77;&#104;&#x69;&#116;&#x61;&#107;&#x65;&#x72;&#x40;&#x6e;&#111;&#x61;&#x61;&#x2e;&#103;&#111;&#x76;</a></p>
 
 <p><strong>copyright</strong>: 2008 by Jeffrey Whitaker.</p>
 
@@ -3082,7 +3082,9 @@ attributes.</p>
         
             <div class="docstring"><p><strong><code>significant_digits(self)</code></strong></p>
 
-<p>return number of significant digits used in quantization</p>
+<p>return number of significant digits used in quantization.
+if returned value is negative, alternate quantization method
+('granular bitgrooming') is used.</p>
 </div>
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1612,7 +1612,7 @@ approaches.</p>
 the parallel IO example, which is in <code>examples/mpi_example.py</code>.
 Unit tests are in the <code>test</code> directory.</p>
 
-<p><strong>contact</strong>: Jeffrey Whitaker <a href="&#x6d;&#97;&#x69;&#108;&#116;&#111;&#58;&#x6a;&#x65;&#x66;&#x66;&#114;ey&#46;&#115;&#x2e;&#x77;&#x68;i&#116;&#97;&#x6b;&#101;&#x72;&#x40;&#x6e;&#x6f;a&#x61;.&#x67;&#111;&#x76;">&#x6a;&#x65;&#x66;&#x66;&#114;ey&#46;&#115;&#x2e;&#x77;&#x68;i&#116;&#97;&#x6b;&#101;&#x72;&#x40;&#x6e;&#x6f;a&#x61;.&#x67;&#111;&#x76;</a></p>
+<p><strong>contact</strong>: Jeffrey Whitaker <a href="&#x6d;&#97;&#105;&#108;&#x74;&#x6f;:&#106;&#101;&#x66;&#x66;&#114;&#101;&#x79;.&#115;.&#119;&#104;&#x69;&#x74;&#x61;&#107;&#x65;&#x72;&#64;&#110;&#x6f;&#x61;&#x61;&#x2e;&#103;&#x6f;&#x76;">&#106;&#101;&#x66;&#x66;&#114;&#101;&#x79;.&#115;.&#119;&#104;&#x69;&#x74;&#x61;&#107;&#x65;&#x72;&#64;&#110;&#x6f;&#x61;&#x61;&#x2e;&#103;&#x6f;&#x76;</a></p>
 
 <p><strong>copyright</strong>: 2008 by Jeffrey Whitaker.</p>
 
@@ -2141,7 +2141,10 @@ retained (in this case bits=4). From the
 in unpacked data that is a reliable value." Default is <code>None</code>, or no
 quantization, or 'lossless' compression.  If <code>significant_digits=3</code>
 then the data will be quantized so that three significant digits are retained, independent
-of the floating point exponent. This option is available only with netcdf-c &gt;= 4.8.2, and 
+of the floating point exponent. If <code>significant_digits</code> is given as a negative
+number, then an alternate algorithm for quantization ('granular bitgrooming') is used
+that may results in better compression for typical geophysical datasets. 
+This <code>significant_digits</code> kwarg is only available  with netcdf-c &gt;= 4.8.2, and 
 only works with <code>NETCDF4</code> or <code>NETCDF4_CLASSIC</code> formatted files.</p>
 
 <p>When creating variables in a <code>NETCDF4</code> or <code>NETCDF4_CLASSIC</code> formatted file,
@@ -2781,10 +2784,13 @@ smallest decimal place in the data the contains a reliable value.  Data is
 truncated to this decimal place when it is assigned to the <code><a href="#Variable">Variable</a></code>
 instance. If <code>None</code>, the data is not truncated.</p>
 
-<p><strong><code><a href="#Variable.significant_digits">significant_digits</a></code></strong>: New in version 1.6.0. Describes the number of significant digits
-in the data the contains a reliable value.  Data is
-truncated to retain this number of significant digits when it is assigned to the <code><a href="#Variable">Variable</a></code>
-instance. If <code>None</code>, the data is not truncated. Only available with netcdf-c &gt;= 4.8.2,
+<p><strong><code><a href="#Variable.significant_digits">significant_digits</a></code></strong>: New in version 1.6.0. Describes the number of significant
+digits in the data the contains a reliable value.  Data is
+truncated to retain this number of significant digits when it is assigned to the
+<code><a href="#Variable">Variable</a></code> instance. If <code>None</code>, the data is not truncated.
+If specified as a negative number, an alternative quantization algorithm is used
+that often produces better compression.
+Only available with netcdf-c &gt;= 4.8.2,
 and only works with <code>NETCDF4</code> or <code>NETCDF4_CLASSIC</code> formatted files.
 The number of significant digits used in the quantization of variable data can be
 obtained using the <code><a href="#Variable.significant_digits">Variable.significant_digits</a></code> method.</p>
@@ -2898,7 +2904,9 @@ so that a precision of 0.1 is retained (in this case bits=4). Default is
 <p><strong><code><a href="#Variable.significant_digits">significant_digits</a></code></strong>: New in version 1.6.0. 
 As described for <code>least_significant_digit</code>
 except the number of significant digits retained is prescribed independent
-of the floating point exponent.  Only available with netcdf-c &gt;= 4.8.2.</p>
+of the floating point exponent.  If specified as a negative number,
+an alternative quantization algorithm is used that often produces
+better compression. Only available with netcdf-c &gt;= 4.8.2.</p>
 
 <p><strong><code>fill_value</code></strong>:  If specified, the default netCDF <code>_FillValue</code> (the
 value that the variable gets filled with before any data is written to it)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1612,7 +1612,7 @@ approaches.</p>
 the parallel IO example, which is in <code>examples/mpi_example.py</code>.
 Unit tests are in the <code>test</code> directory.</p>
 
-<p><strong>contact</strong>: Jeffrey Whitaker <a href="&#x6d;&#97;&#105;&#108;&#x74;&#x6f;:&#106;&#101;&#x66;&#x66;&#114;&#101;&#x79;.&#115;.&#119;&#104;&#x69;&#x74;&#x61;&#107;&#x65;&#x72;&#64;&#110;&#x6f;&#x61;&#x61;&#x2e;&#103;&#x6f;&#x76;">&#106;&#101;&#x66;&#x66;&#114;&#101;&#x79;.&#115;.&#119;&#104;&#x69;&#x74;&#x61;&#107;&#x65;&#x72;&#64;&#110;&#x6f;&#x61;&#x61;&#x2e;&#103;&#x6f;&#x76;</a></p>
+<p><strong>contact</strong>: Jeffrey Whitaker <a href="&#109;&#97;&#x69;&#108;&#116;&#x6f;&#58;&#x6a;&#101;&#x66;&#102;&#114;&#101;&#121;&#x2e;&#x73;&#46;wh&#x69;&#116;&#x61;&#x6b;&#101;&#x72;&#64;&#110;&#111;&#97;&#x61;&#x2e;&#103;&#x6f;&#118;">&#x6a;&#101;&#x66;&#102;&#114;&#101;&#121;&#x2e;&#x73;&#46;wh&#x69;&#116;&#x61;&#x6b;&#101;&#x72;&#64;&#110;&#111;&#97;&#x61;&#x2e;&#103;&#x6f;&#118;</a></p>
 
 <p><strong>copyright</strong>: 2008 by Jeffrey Whitaker.</p>
 
@@ -1742,8 +1742,10 @@ set this is just used to set the <code><a href="#Dataset.filepath">filepath()</a
 
 <p><strong><code>mode</code></strong>: access mode. <code>r</code> means read-only; no data can be
 modified. <code>w</code> means write; a new file is created, an existing file with
-the same name is deleted. <code>a</code> and <code>r+</code> mean append (in analogy with
-serial files); an existing file is opened for reading and writing.
+the same name is deleted. 'x' means write, but fail if an existing
+file with the same name already exists. <code>a</code> and <code>r+</code> mean append; 
+an existing file is opened for reading and writing, if 
+file does not exist already, one is created.
 Appending <code>s</code> to modes <code>r</code>, <code>w</code>, <code>r+</code> or <code>a</code> will enable unbuffered shared
 access to <code>NETCDF3_CLASSIC</code>, <code>NETCDF3_64BIT_OFFSET</code> or
 <code>NETCDF3_64BIT_DATA</code> formatted files.
@@ -1754,7 +1756,8 @@ formatted files.</p>
 
 <p><strong><code>clobber</code></strong>: if <code>True</code> (default), opening a file with <code>mode='w'</code>
 will clobber an existing file with the same name.  if <code>False</code>, an
-exception will be raised if a file with the same name already exists.</p>
+exception will be raised if a file with the same name already exists.
+mode='x' is identical to mode='w' with clobber=False.</p>
 
 <p><strong><code>format</code></strong>: underlying file format (one of <code>'NETCDF4',
 'NETCDF4_CLASSIC', 'NETCDF3_CLASSIC'</code>, <code>'NETCDF3_64BIT_OFFSET'</code> or
@@ -2143,7 +2146,7 @@ quantization, or 'lossless' compression.  If <code>significant_digits=3</code>
 then the data will be quantized so that three significant digits are retained, independent
 of the floating point exponent. If <code>significant_digits</code> is given as a negative
 number, then an alternate algorithm for quantization ('granular bitgrooming') is used
-that may results in better compression for typical geophysical datasets. 
+that may result in better compression for typical geophysical datasets. 
 This <code>significant_digits</code> kwarg is only available  with netcdf-c &gt;= 4.8.2, and 
 only works with <code>NETCDF4</code> or <code>NETCDF4_CLASSIC</code> formatted files.</p>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1612,8 +1612,7 @@ approaches.</p>
 the parallel IO example, which is in <code>examples/mpi_example.py</code>.
 Unit tests are in the <code>test</code> directory.</p>
 
-
-<p><strong>contact</strong>: Jeffrey Whitaker <a href="&#109;&#97;&#105;&#x6c;&#116;o&#x3a;&#106;&#101;&#102;&#102;&#x72;&#x65;&#x79;&#x2e;&#x73;&#x2e;&#x77;&#104;&#x69;&#116;&#x61;&#107;&#x65;&#x72;&#x40;&#x6e;&#111;&#x61;&#x61;&#x2e;&#103;&#111;&#x76;">&#106;&#101;&#102;&#102;&#x72;&#x65;&#x79;&#x2e;&#x73;&#x2e;&#x77;&#104;&#x69;&#116;&#x61;&#107;&#x65;&#x72;&#x40;&#x6e;&#111;&#x61;&#x61;&#x2e;&#103;&#111;&#x76;</a></p>
+<p><strong>contact</strong>: Jeffrey Whitaker <a href="&#109;&#97;&#x69;&#108;&#x74;&#111;&#58;&#x6a;&#x65;&#x66;f&#114;&#101;&#121;&#x2e;&#115;&#46;&#x77;&#104;it&#97;&#107;&#x65;&#114;&#64;&#110;&#x6f;&#97;&#x61;.&#x67;&#111;&#118;">&#x6a;&#x65;&#x66;f&#114;&#101;&#121;&#x2e;&#115;&#46;&#x77;&#104;it&#97;&#107;&#x65;&#114;&#64;&#110;&#x6f;&#97;&#x61;.&#x67;&#111;&#118;</a></p>
 
 <p><strong>copyright</strong>: 2008 by Jeffrey Whitaker.</p>
 

--- a/examples/bench_compress4.py
+++ b/examples/bench_compress4.py
@@ -1,0 +1,56 @@
+from __future__ import print_function
+# benchmark reads and writes, with and without compression.
+# tests all four supported file formats.
+from numpy.random.mtrand import uniform
+import netCDF4
+from timeit import Timer
+import os, sys
+
+# use real data.
+URL="http://www.esrl.noaa.gov/psd/thredds/dodsC/Datasets/ncep.reanalysis/pressure/hgt.1990.nc"
+nc = netCDF4.Dataset(URL)
+
+# use real 500 hPa geopotential height data.
+n1dim = 100
+n3dim = 73
+n4dim = 144
+ntrials = 10
+sys.stdout.write('reading and writing a %s by %s by %s random array ..\n'%(n1dim,n3dim,n4dim))
+sys.stdout.write('(average of %s trials)\n\n' % ntrials)
+print(nc)
+print(nc.variables['hgt'])
+array = nc.variables['hgt'][0:n1dim,5,:,:]
+print(array.min(), array.max(), array.shape, array.dtype)
+
+
+def write_netcdf(filename,nsd):
+    file = netCDF4.Dataset(filename,'w',format='NETCDF4')
+    file.createDimension('n1', None)
+    file.createDimension('n3', n3dim)
+    file.createDimension('n4', n4dim)
+    foo = file.createVariable('data',\
+                              'f4',('n1','n3','n4'),\
+                              zlib=True,shuffle=True,\
+                              significant_digits=nsd)
+    foo[:] = array
+    file.close()
+
+def read_netcdf(filename):
+    file = netCDF4.Dataset(filename)
+    data = file.variables['data'][:]
+    file.close()
+
+for sigdigits in range(1,6,1):
+    sys.stdout.write('testing compression with significant_digits=%s...\n' %\
+            sigdigits)
+    write_netcdf('test.nc',sigdigits)
+    read_netcdf('test.nc')
+    # print out size of resulting files with standard quantization.
+    sys.stdout.write('size of test.nc = %s\n'%repr(os.stat('test.nc').st_size))
+    sigdigits_neg = -sigdigits
+    sys.stdout.write('testing compression with significant_digits=%s...\n' %\
+            sigdigits_neg)
+    write_netcdf('test.nc',sigdigits_neg)
+    read_netcdf('test.nc')
+    # print out size of resulting files with alternate quantization.
+    sys.stdout.write('size of test.nc = %s\n'%repr(os.stat('test.nc').st_size))

--- a/examples/bench_compress4.py
+++ b/examples/bench_compress4.py
@@ -17,10 +17,7 @@ n4dim = 144
 ntrials = 10
 sys.stdout.write('reading and writing a %s by %s by %s random array ..\n'%(n1dim,n3dim,n4dim))
 sys.stdout.write('(average of %s trials)\n\n' % ntrials)
-print(nc)
-print(nc.variables['hgt'])
 array = nc.variables['hgt'][0:n1dim,5,:,:]
-print(array.min(), array.max(), array.shape, array.dtype)
 
 
 def write_netcdf(filename,nsd):
@@ -40,7 +37,7 @@ def read_netcdf(filename):
     data = file.variables['data'][:]
     file.close()
 
-for sigdigits in range(1,6,1):
+for sigdigits in range(1,5,1):
     sys.stdout.write('testing compression with significant_digits=%s...\n' %\
             sigdigits)
     write_netcdf('test.nc',sigdigits)

--- a/include/netCDF4.pxi
+++ b/include/netCDF4.pxi
@@ -691,6 +691,14 @@ cdef extern from "netcdf.h":
     int nc_inq_enum_ident(int ncid, nc_type xtype, long long value, char *identifier) nogil
 
 
+IF HAS_QUANTIZATION_SUPPORT:
+    cdef extern from "netcdf.h":
+        cdef enum:
+            NC_NOQUANTIZE
+            NC_QUANTIZE_BITGROOM
+        int nc_def_var_quantize(int ncid, int varid, int quantize_mode, int nsd) 
+        int nc_inq_var_quantize(int ncid, int varid, int *quantize_modep, int *nsdp) nogil
+
 IF HAS_NC_OPEN_MEM:
     cdef extern from "netcdf_mem.h":
         int nc_open_mem(const char *path, int mode, size_t size, void* memory, int *ncidp)

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ def check_api(inc_dirs,netcdf_lib_version):
     has_parallel_support = False
     has_parallel4_support = False
     has_pnetcdf_support = False
+    has_quantize = False
 
     for d in inc_dirs:
         try:
@@ -83,6 +84,8 @@ def check_api(inc_dirs,netcdf_lib_version):
                 has_nc_inq_format_extended = True
             if line.startswith('#define NC_FORMAT_64BIT_DATA'):
                 has_cdf5_format = True
+            if line.startswith('nc_def_var_quantize'):
+                has_quantize = True
 
         if has_nc_open_mem:
             try:
@@ -116,7 +119,7 @@ def check_api(inc_dirs,netcdf_lib_version):
 
     return has_rename_grp, has_nc_inq_path, has_nc_inq_format_extended, \
            has_cdf5_format, has_nc_open_mem, has_nc_create_mem, \
-           has_parallel4_support, has_pnetcdf_support
+           has_parallel4_support, has_pnetcdf_support, has_quantize
 
 
 def getnetcdfvers(libdirs):
@@ -529,7 +532,7 @@ if 'sdist' not in sys.argv[1:] and 'clean' not in sys.argv[1:] and '--version' n
     # this determines whether renameGroup and filepath methods will work.
     has_rename_grp, has_nc_inq_path, has_nc_inq_format_extended, \
     has_cdf5_format, has_nc_open_mem, has_nc_create_mem, \
-    has_parallel4_support, has_pnetcdf_support = \
+    has_parallel4_support, has_pnetcdf_support, has_quantize = \
     check_api(inc_dirs,netcdf_lib_version)
     # for netcdf 4.4.x CDF5 format is always enabled.
     if netcdf_lib_version is not None and\
@@ -600,6 +603,13 @@ if 'sdist' not in sys.argv[1:] and 'clean' not in sys.argv[1:] and '--version' n
     else:
         sys.stdout.write('netcdf lib does not have pnetcdf parallel functions\n')
         f.write('DEF HAS_PNETCDF_SUPPORT = 0\n')
+
+    if has_quantize:
+        sys.stdout.write('netcdf lib has bit-grooming/quantization functions\n')
+        f.write('DEF HAS_QUANTIZATION_SUPPORT = 1\n')
+    else:
+        sys.stdout.write('netcdf lib does not bit-grooming/quantization functions\n')
+        f.write('DEF HAS_QUANTIZATION_SUPPORT = 0\n')
 
     f.close()
 

--- a/src/netCDF4/__init__.py
+++ b/src/netCDF4/__init__.py
@@ -7,6 +7,6 @@ from ._netCDF4 import (__version__, __netcdf4libversion__, __hdf5libversion__,
                        __has_rename_grp__, __has_nc_inq_path__,
                        __has_nc_inq_format_extended__, __has_nc_open_mem__,
                        __has_nc_create_mem__, __has_cdf5_format__,
-                       __has_parallel4_support__, __has_pnetcdf_support__)
+                       __has_parallel4_support__, __has_pnetcdf_support__,__has_quantization_support__)
 __all__ =\
 ['Dataset','Variable','Dimension','Group','MFDataset','MFTime','CompoundType','VLType','date2num','num2date','date2index','stringtochar','chartostring','stringtoarr','getlibversion','EnumType','get_chunk_cache','set_chunk_cache']

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -2613,11 +2613,11 @@ datatype."""
     def createVariable(self, varname, datatype, dimensions=(), zlib=False,
             complevel=4, shuffle=True, fletcher32=False, contiguous=False,
             chunksizes=None, endian='native', least_significant_digit=None,
-            fill_value=None, chunk_cache=None):
+            significant_digits=None,fill_value=None, chunk_cache=None):
         """
 **`createVariable(self, varname, datatype, dimensions=(), zlib=False,
 complevel=4, shuffle=True, fletcher32=False, contiguous=False, chunksizes=None,
-endian='native', least_significant_digit=None, fill_value=None, chunk_cache=None)`**
+endian='native', least_significant_digit=None, significant_digits=None, fill_value=None, chunk_cache=None)`**
 
 Creates a new variable with the given `varname`, `datatype`, and
 `dimensions`. If dimensions are not given, the variable is assumed to be
@@ -2749,7 +2749,7 @@ is the number of variable dimensions."""
         dimensions=dimensions, zlib=zlib, complevel=complevel, shuffle=shuffle,
         fletcher32=fletcher32, contiguous=contiguous, chunksizes=chunksizes,
         endian=endian, least_significant_digit=least_significant_digit,
-        fill_value=fill_value, chunk_cache=chunk_cache)
+        significant_digits=None,fill_value=fill_value, chunk_cache=chunk_cache)
         return group.variables[varname]
 
     def renameVariable(self, oldname, newname):
@@ -3571,7 +3571,7 @@ behavior is similar to Fortran or Matlab, but different than numpy.
     def __init__(self, grp, name, datatype, dimensions=(), zlib=False,
             complevel=4, shuffle=True, fletcher32=False, contiguous=False,
             chunksizes=None, endian='native', least_significant_digit=None,
-            fill_value=None, chunk_cache=None, **kwargs):
+            significant_digits=None,fill_value=None, chunk_cache=None, **kwargs):
         """
         **`__init__(self, group, name, datatype, dimensions=(), zlib=False,
         complevel=4, shuffle=True, fletcher32=False, contiguous=False,
@@ -3666,7 +3666,7 @@ behavior is similar to Fortran or Matlab, but different than numpy.
         `Dataset.createVariable` method of a `Dataset` or
         `Group` instance, not using this class directly.
         """
-        cdef int ierr, ndims, icontiguous, ideflate_level, numdims, _grpid
+        cdef int ierr, ndims, icontiguous, ideflate_level, numdims, _grpid, nsd
         cdef char namstring[NC_MAX_NAME+1]
         cdef char *varname
         cdef nc_type xtype
@@ -3865,6 +3865,11 @@ behavior is similar to Fortran or Matlab, but different than numpy.
                     pass # this is the default format.
                 else:
                     raise ValueError("'endian' keyword argument must be 'little','big' or 'native', got '%s'" % endian)
+                # set quantization
+                IF HAS_QUANTIZATION_SUPPORT:
+                    if significant_digits is not None:
+                        nsd = significant_digits
+                        ierr = nc_def_var_quantize(self._grpid, self._varid, NC_QUANTIZE_BITGROOM, nsd)
                 if ierr != NC_NOERR:
                     if grp.data_model != 'NETCDF4': grp._enddef()
                     _ensure_nc_success(ierr)
@@ -4200,6 +4205,30 @@ return dictionary containing HDF5 filter parameters."""
         if ifletcher32:
             filtdict['fletcher32']=True
         return filtdict
+
+    def significant_digits(self):
+        """
+**`significant_digits(self)`**
+
+return number of significant digits used in quantization"""
+        IF HAS_QUANTIZATION_SUPPORT:
+            cdef int ierr, nsd, quantize_mode
+            if self._grp.data_model not in ['NETCDF4_CLASSIC','NETCDF4']:
+                return None
+            else:
+                with nogil:
+                    ierr = nc_inq_var_quantize(self._grpid, self._varid, &quantize_mode, &nsd)
+                _ensure_nc_success(ierr)
+                if quantize_mode == NC_NOQUANTIZE:
+                    return None
+                else:
+                    sig_digits = nsd
+                    return sig_digits
+        ELSE:
+            msg = """
+significant_digits method not enabled.  To enable, install Cython, make sure you have
+version 4.8.2 or higher of the netcdf C lib, and rebuild netcdf4-python."""
+            raise ValueError(msg)
 
     def endian(self):
         """

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -2722,7 +2722,10 @@ retained (in this case bits=4). From the
 in unpacked data that is a reliable value." Default is `None`, or no
 quantization, or 'lossless' compression.  If `significant_digits=3`
 then the data will be quantized so that three significant digits are retained, independent
-of the floating point exponent. This option is available only with netcdf-c >= 4.8.2, and 
+of the floating point exponent. If `significant_digits` is given as a negative
+number, then an alternate algorithm for quantization ('granular bitgrooming') is used
+that may results in better compression for typical geophysical datasets. 
+This `significant_digits` kwarg is only available  with netcdf-c >= 4.8.2, and 
 only works with `NETCDF4` or `NETCDF4_CLASSIC` formatted files.
 
 When creating variables in a `NETCDF4` or `NETCDF4_CLASSIC` formatted file,
@@ -3574,10 +3577,13 @@ smallest decimal place in the data the contains a reliable value.  Data is
 truncated to this decimal place when it is assigned to the `Variable`
 instance. If `None`, the data is not truncated.
 
-**`significant_digits`**: New in version 1.6.0. Describes the number of significant digits
-in the data the contains a reliable value.  Data is
-truncated to retain this number of significant digits when it is assigned to the `Variable`
-instance. If `None`, the data is not truncated. Only available with netcdf-c >= 4.8.2,
+**`significant_digits`**: New in version 1.6.0. Describes the number of significant
+digits in the data the contains a reliable value.  Data is
+truncated to retain this number of significant digits when it is assigned to the
+`Variable` instance. If `None`, the data is not truncated.
+If specified as a negative number, an alternative quantization algorithm is used
+that often produces better compression.
+Only available with netcdf-c >= 4.8.2,
 and only works with `NETCDF4` or `NETCDF4_CLASSIC` formatted files.
 The number of significant digits used in the quantization of variable data can be
 obtained using the `Variable.significant_digits` method.
@@ -3691,7 +3697,9 @@ behavior is similar to Fortran or Matlab, but different than numpy.
         **`significant_digits`**: New in version 1.6.0. 
         As described for `least_significant_digit`
         except the number of significant digits retained is prescribed independent
-        of the floating point exponent.  Only available with netcdf-c >= 4.8.2.
+        of the floating point exponent.  If specified as a negative number,
+        an alternative quantization algorithm is used that often produces
+        better compression. Only available with netcdf-c >= 4.8.2.
 
         **`fill_value`**:  If specified, the default netCDF `_FillValue` (the
         value that the variable gets filled with before any data is written to it)

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -2733,7 +2733,7 @@ quantization, or 'lossless' compression.  If `significant_digits=3`
 then the data will be quantized so that three significant digits are retained, independent
 of the floating point exponent. If `significant_digits` is given as a negative
 number, then an alternate algorithm for quantization ('granular bitgrooming') is used
-that may results in better compression for typical geophysical datasets. 
+that may result in better compression for typical geophysical datasets. 
 This `significant_digits` kwarg is only available  with netcdf-c >= 4.8.2, and 
 only works with `NETCDF4` or `NETCDF4_CLASSIC` formatted files.
 

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -3873,8 +3873,9 @@ behavior is similar to Fortran or Matlab, but different than numpy.
                 ELSE:
                     if significant_digits is not None:
                         msg = """
-significant_digits feature not enabled.  To enable, install Cython, make sure you have
-version 4.8.2 or higher of the netcdf C lib, and rebuild netcdf4-python."""
+significant_digits kwarge only works with netcdf-c >= 4.8.2.  To enable, install Cython, make sure you have
+version 4.8.2 or higher netcdf-c, and rebuild netcdf4-python. Otherwise, use least_significant_digit
+kwarg for quantization."""
                         raise ValueError(msg)
                 if ierr != NC_NOERR:
                     if grp.data_model != 'NETCDF4': grp._enddef()
@@ -4231,10 +4232,7 @@ return number of significant digits used in quantization"""
                     sig_digits = nsd
                     return sig_digits
         ELSE:
-            msg = """
-significant_digits method not enabled.  To enable, install Cython, make sure you have
-version 4.8.2 or higher of the netcdf C lib, and rebuild netcdf4-python."""
-            raise ValueError(msg)
+            return None
 
     def endian(self):
         """

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -667,7 +667,7 @@ If your data only has a certain number of digits of precision (say for
 example, it is temperature data that was measured with a precision of
 0.1 degrees), you can dramatically improve zlib compression by
 quantizing (or truncating) the data. There are two methods supplied for
-doing this.  You can useg the `least_significant_digit`
+doing this.  You can use the `least_significant_digit`
 keyword argument to `Dataset.createVariable` to specify
 the power of ten of the smallest decimal place in
 the data that is a reliable value. For example if the data has a
@@ -2717,7 +2717,8 @@ retained (in this case bits=4). From the
 in unpacked data that is a reliable value." Default is `None`, or no
 quantization, or 'lossless' compression.  If `significant_digits=3`
 then the data will be quantized so that three significant digits are retained, independent
-of the floating point exponent. This option is available only with netcdf-c >= 4.8.2.
+of the floating point exponent. This option is available only with netcdf-c >= 4.8.2, and 
+only works with `NETCDF4` or `NETCDF4_CLASSIC` formatted files.
 
 When creating variables in a `NETCDF4` or `NETCDF4_CLASSIC` formatted file,
 HDF5 creates something called a 'chunk cache' for each variable.  The
@@ -3571,7 +3572,8 @@ instance. If `None`, the data is not truncated.
 **`significant_digits`**: Describes the number of significant digits
 in the data the contains a reliable value.  Data is
 truncated to retain this number of significant digits when it is assigned to the `Variable`
-instance. If `None`, the data is not truncated. Only available with netcdf-c >= 4.8.2.
+instance. If `None`, the data is not truncated. Only available with netcdf-c >= 4.8.2,
+and only works with `NETCDF4` or `NETCDF4_CLASSIC` formatted files.
 The number of significant digits used in the quantization of variable data can be
 obtained using the `Variable.significant_digits` method.
 

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -1304,6 +1304,7 @@ __has_nc_open_mem__ = HAS_NC_OPEN_MEM
 __has_nc_create_mem__ = HAS_NC_CREATE_MEM
 __has_parallel4_support__ = HAS_PARALLEL4_SUPPORT
 __has_pnetcdf_support__ = HAS_PNETCDF_SUPPORT
+__has_quantization_support__ = HAS_QUANTIZATION_SUPPORT
 _needsworkaround_issue485 = __netcdf4libversion__ < "4.4.0" or \
                (__netcdf4libversion__.startswith("4.4.0") and \
                 "-development" in __netcdf4libversion__)
@@ -2749,7 +2750,7 @@ is the number of variable dimensions."""
         dimensions=dimensions, zlib=zlib, complevel=complevel, shuffle=shuffle,
         fletcher32=fletcher32, contiguous=contiguous, chunksizes=chunksizes,
         endian=endian, least_significant_digit=least_significant_digit,
-        significant_digits=None,fill_value=fill_value, chunk_cache=chunk_cache)
+        significant_digits=significant_digits,fill_value=fill_value, chunk_cache=chunk_cache)
         return group.variables[varname]
 
     def renameVariable(self, oldname, newname):

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -3870,6 +3870,12 @@ behavior is similar to Fortran or Matlab, but different than numpy.
                     if significant_digits is not None:
                         nsd = significant_digits
                         ierr = nc_def_var_quantize(self._grpid, self._varid, NC_QUANTIZE_BITGROOM, nsd)
+                ELSE:
+                    if significant_digits is not None:
+                        msg = """
+significant_digits feature not enabled.  To enable, install Cython, make sure you have
+version 4.8.2 or higher of the netcdf C lib, and rebuild netcdf4-python."""
+                        raise ValueError(msg)
                 if ierr != NC_NOERR:
                     if grp.data_model != 'NETCDF4': grp._enddef()
                     _ensure_nc_success(ierr)

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -677,7 +677,8 @@ scale = 2**bits, and bits is determined so that a precision of 0.1 is
 retained (in this case bits=4).  This is done at the python level and is
 not a part of the underlying C library.  Starting with netcdf-c version 4.8.2,
 a quantization capability is provided in the library.  This can be
-used via the `significant_digits` `Dataset.createVariable` kwarg.
+used via the `significant_digits` `Dataset.createVariable` kwarg (new in
+version 1.6.0).
 The interpretation of `significant_digits` is different than `least_signficant_digit`
 in that it specifies the absolute number of significant digits independent
 of the magnitude of the variable (the floating point exponent).
@@ -3573,7 +3574,7 @@ smallest decimal place in the data the contains a reliable value.  Data is
 truncated to this decimal place when it is assigned to the `Variable`
 instance. If `None`, the data is not truncated.
 
-**`significant_digits`**: Describes the number of significant digits
+**`significant_digits`**: New in version 1.6.0. Describes the number of significant digits
 in the data the contains a reliable value.  Data is
 truncated to retain this number of significant digits when it is assigned to the `Variable`
 instance. If `None`, the data is not truncated. Only available with netcdf-c >= 4.8.2,
@@ -3687,7 +3688,8 @@ behavior is similar to Fortran or Matlab, but different than numpy.
         so that a precision of 0.1 is retained (in this case bits=4). Default is
         `None`, or no quantization.
 
-        **`significant_digits`**: As described for `least_significant_digit`
+        **`significant_digits`**: New in version 1.6.0. 
+        As described for `least_significant_digit`
         except the number of significant digits retained is prescribed independent
         of the floating point exponent.  Only available with netcdf-c >= 4.8.2.
 

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -3902,7 +3902,7 @@ behavior is similar to Fortran or Matlab, but different than numpy.
                 ELSE:
                     if significant_digits is not None:
                         msg = """
-significant_digits kwarge only works with netcdf-c >= 4.8.2.  To enable, install Cython, make sure you have
+significant_digits kwarg only works with netcdf-c >= 4.8.2.  To enable, install Cython, make sure you have
 version 4.8.2 or higher netcdf-c, and rebuild netcdf4-python. Otherwise, use least_significant_digit
 kwarg for quantization."""
                         raise ValueError(msg)

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -4282,7 +4282,10 @@ return dictionary containing HDF5 filter parameters."""
         """
 **`significant_digits(self)`**
 
-return number of significant digits used in quantization"""
+return number of significant digits used in quantization.
+if returned value is negative, alternate quantization method
+('granular bitgrooming') is used.
+"""
         IF HAS_QUANTIZATION_SUPPORT:
             cdef int ierr, nsd, quantize_mode
             if self._grp.data_model not in ['NETCDF4_CLASSIC','NETCDF4']:

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -3835,18 +3835,6 @@ behavior is similar to Fortran or Matlab, but different than numpy.
             if ierr != NC_NOERR:
                 if grp.data_model != 'NETCDF4': grp._enddef()
                 _ensure_nc_success(ierr)
-            # set quantization in netcdf-c >= 4.8.2
-            IF HAS_QUANTIZATION_SUPPORT:
-                if significant_digits is not None:
-                    nsd = significant_digits
-                    ierr = nc_def_var_quantize(self._grpid, self._varid, NC_QUANTIZE_BITGROOM, nsd)
-            ELSE:
-                if significant_digits is not None:
-                    msg = """
-significant_digits kwarg only works with netcdf-c >= 4.8.2.  To enable, install Cython, make sure you have
-version 4.8.2 or higher netcdf-c, and rebuild netcdf4-python. Otherwise, use least_significant_digit
-kwarg for quantization."""
-                    raise ValueError(msg)
             # set zlib, shuffle, chunking, fletcher32 and endian
             # variable settings.
             # don't bother for NETCDF3* formats.
@@ -3906,6 +3894,18 @@ kwarg for quantization."""
                     pass # this is the default format.
                 else:
                     raise ValueError("'endian' keyword argument must be 'little','big' or 'native', got '%s'" % endian)
+                # set quantization
+                IF HAS_QUANTIZATION_SUPPORT:
+                    if significant_digits is not None:
+                        nsd = significant_digits
+                        ierr = nc_def_var_quantize(self._grpid, self._varid, NC_QUANTIZE_BITGROOM, nsd)
+                ELSE:
+                    if significant_digits is not None:
+                        msg = """
+significant_digits kwarg only works with netcdf-c >= 4.8.2.  To enable, install Cython, make sure you have
+version 4.8.2 or higher netcdf-c, and rebuild netcdf4-python. Otherwise, use least_significant_digit
+kwarg for quantization."""
+                        raise ValueError(msg)
                 if ierr != NC_NOERR:
                     if grp.data_model != 'NETCDF4': grp._enddef()
                     _ensure_nc_success(ierr)
@@ -4249,14 +4249,17 @@ return dictionary containing HDF5 filter parameters."""
 return number of significant digits used in quantization"""
         IF HAS_QUANTIZATION_SUPPORT:
             cdef int ierr, nsd, quantize_mode
-            with nogil:
-                ierr = nc_inq_var_quantize(self._grpid, self._varid, &quantize_mode, &nsd)
-            _ensure_nc_success(ierr)
-            if quantize_mode == NC_NOQUANTIZE:
+            if self._grp.data_model not in ['NETCDF4_CLASSIC','NETCDF4']:
                 return None
             else:
-                sig_digits = nsd
-                return sig_digits
+                with nogil:
+                    ierr = nc_inq_var_quantize(self._grpid, self._varid, &quantize_mode, &nsd)
+                _ensure_nc_success(ierr)
+                if quantize_mode == NC_NOQUANTIZE:
+                    return None
+                else:
+                    sig_digits = nsd
+                    return sig_digits
         ELSE:
             return None
 

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -1,5 +1,5 @@
 """
-Version 1.5.8
+Version 1.6.0
 -------------
 
 # Introduction
@@ -1204,7 +1204,7 @@ if sys.version_info[0:2] < (3, 7):
     # Python 3.7+ guarantees order; older versions need OrderedDict
     from collections import OrderedDict
 
-__version__ = "1.5.8"
+__version__ = "1.6.0"
 
 # Initialize numpy
 import posixpath

--- a/test/run_all.py
+++ b/test/run_all.py
@@ -1,7 +1,7 @@
 import glob, os, sys, unittest, struct
 from netCDF4 import getlibversion,__hdf5libversion__,__netcdf4libversion__,__version__
 from netCDF4 import __has_cdf5_format__, __has_nc_inq_path__, __has_nc_create_mem__, \
-                    __has_parallel4_support__, __has_pnetcdf_support__
+                    __has_parallel4_support__, __has_pnetcdf_support__, __has_quantization_support__
 
 # can also just run
 # python -m unittest discover . 'tst*py'
@@ -20,6 +20,9 @@ if not __has_nc_create_mem__:
 if not __has_cdf5_format__ or struct.calcsize("P") < 8:
     test_files.remove('tst_cdf5.py')
     sys.stdout.write('not running tst_cdf5.py ...\n')
+if not __has_quantization_support__:
+    test_files.remove('tst_compression2.py')
+    sys.stdout.write('not running tst_compression2.py ...\n')
 
 # Don't run tests that require network connectivity
 if os.getenv('NO_NET'):

--- a/test/tst_compression2.py
+++ b/test/tst_compression2.py
@@ -1,0 +1,88 @@
+from numpy.random.mtrand import uniform
+from netCDF4 import Dataset
+from netCDF4.utils import _quantize
+from numpy.testing import assert_almost_equal
+import numpy as np
+import os, tempfile, unittest
+
+ndim = 100000
+nfiles = 5
+files = [tempfile.NamedTemporaryFile(suffix='.nc', delete=False).name for nfile in range(nfiles)]
+array = uniform(size=(ndim,))
+nsd = 3
+complevel = 6
+
+def write_netcdf(filename,zlib,significant_digits,data,dtype='f8',shuffle=False,\
+                 complevel=6):
+    file = Dataset(filename,'w')
+    file.createDimension('n', ndim)
+    foo = file.createVariable('data',\
+            dtype,('n'),zlib=zlib,significant_digits=significant_digits,\
+            shuffle=shuffle,complevel=complevel)
+    foo[:] = data
+    file.close()
+    file = Dataset(filename)
+    data = file.variables['data'][:]
+    file.close()
+
+class CompressionTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.files = files
+        # no compression
+        write_netcdf(self.files[0],False,None,array)
+        # compressed, lossless, no shuffle.
+        write_netcdf(self.files[1],True,None,array)
+        # compressed, lossless, with shuffle.
+        write_netcdf(self.files[2],True,None,array,shuffle=True)
+        # compressed, lossy, no shuffle.
+        write_netcdf(self.files[3],True,nsd,array)
+        # compressed, lossy, with shuffle.
+        write_netcdf(self.files[4],True,nsd,array,shuffle=True)
+
+    def tearDown(self):
+        # Remove the temporary files
+        for file in self.files:
+            os.remove(file)
+
+    def runTest(self):
+        """testing zlib and shuffle compression filters"""
+        uncompressed_size = os.stat(self.files[0]).st_size
+        #print('uncompressed size = ',uncompressed_size)
+        # check compressed data.
+        f = Dataset(self.files[1])
+        size = os.stat(self.files[1]).st_size
+        #print('compressed lossless no shuffle = ',size)
+        assert_almost_equal(array,f.variables['data'][:])
+        assert f.variables['data'].filters() == {'zlib':True,'shuffle':False,'complevel':complevel,'fletcher32':False}
+        assert(size < 0.95*uncompressed_size)
+        f.close()
+        # check compression with shuffle
+        f = Dataset(self.files[2])
+        size = os.stat(self.files[2]).st_size
+        #print('compressed lossless with shuffle ',size)
+        assert_almost_equal(array,f.variables['data'][:])
+        assert f.variables['data'].filters() == {'zlib':True,'shuffle':True,'complevel':complevel,'fletcher32':False}
+        assert(size < 0.85*uncompressed_size)
+        f.close()
+        # check lossy compression without shuffle
+        f = Dataset(self.files[3])
+        size = os.stat(self.files[3]).st_size
+        errmax = (np.abs(array-f.variables['data'][:])).max()
+        #print('compressed lossy no shuffle = ',size,' max err = ',errmax)
+        assert(f.variables['data'].significant_digits() == nsd)
+        assert(errmax < 1.e-3)
+        assert(size < 0.35*uncompressed_size)
+        f.close()
+        # check lossy compression with shuffle
+        f = Dataset(self.files[4])
+        size = os.stat(self.files[4]).st_size
+        errmax = (np.abs(array-f.variables['data'][:])).max()
+        #print('compressed lossy with shuffle = ',size,' max err = ',errmax)
+        assert(f.variables['data'].significant_digits() == nsd)
+        assert(errmax < 1.e-3)
+        assert(size < 0.24*uncompressed_size)
+        f.close()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/tst_compression2.py
+++ b/test/tst_compression2.py
@@ -6,7 +6,7 @@ import numpy as np
 import os, tempfile, unittest
 
 ndim = 100000
-nfiles = 5
+nfiles = 6
 files = [tempfile.NamedTemporaryFile(suffix='.nc', delete=False).name for nfile in range(nfiles)]
 array = uniform(size=(ndim,))
 nsd = 3
@@ -39,6 +39,8 @@ class CompressionTestCase(unittest.TestCase):
         write_netcdf(self.files[3],True,nsd,array)
         # compressed, lossy, with shuffle.
         write_netcdf(self.files[4],True,nsd,array,shuffle=True)
+        # compressed, lossy, with shuffle, and alternate quantization.
+        write_netcdf(self.files[5],True,-nsd,array,shuffle=True)
 
     def tearDown(self):
         # Remove the temporary files
@@ -78,7 +80,16 @@ class CompressionTestCase(unittest.TestCase):
         f = Dataset(self.files[4])
         size = os.stat(self.files[4]).st_size
         errmax = (np.abs(array-f.variables['data'][:])).max()
-        #print('compressed lossy with shuffle = ',size,' max err = ',errmax)
+        print('compressed lossy with shuffle and standard quantization = ',size,' max err = ',errmax)
+        assert(f.variables['data'].significant_digits() == nsd)
+        assert(errmax < 1.e-3)
+        assert(size < 0.24*uncompressed_size)
+        f.close()
+        # check lossy compression with shuffle and alternate quantization
+        f = Dataset(self.files[5])
+        size = os.stat(self.files[5]).st_size
+        errmax = (np.abs(array-f.variables['data'][:])).max()
+        print('compressed lossy with shuffle and alternate quantization = ',size,' max err = ',errmax)
         assert(f.variables['data'].significant_digits() == nsd)
         assert(errmax < 1.e-3)
         assert(size < 0.24*uncompressed_size)

--- a/test/tst_compression2.py
+++ b/test/tst_compression2.py
@@ -90,7 +90,7 @@ class CompressionTestCase(unittest.TestCase):
         size = os.stat(self.files[5]).st_size
         errmax = (np.abs(array-f.variables['data'][:])).max()
         print('compressed lossy with shuffle and alternate quantization = ',size,' max err = ',errmax)
-        assert(f.variables['data'].significant_digits() == nsd)
+        assert(f.variables['data'].significant_digits() == -nsd)
         assert(errmax < 1.e-3)
         assert(size < 0.24*uncompressed_size)
         f.close()


### PR DESCRIPTION
WIP - using "significant_digits" kwarg in createVariable.

Question: what do to about old "least_signficant_digit" kwarg?  Retain for compatibility?  Issue warning if both specified?