### PR TITLE
Define MPI_Session for compatibility with current mpi4py main branch

### DIFF
--- a/.github/workflows/miniconda.yml
+++ b/.github/workflows/miniconda.yml
@@ -78,7 +78,7 @@ jobs:
         export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" 
         which mpirun
         mpirun --version
-        mpirun -np 4 python mpi_example.py
+        mpirun -np 4 --oversubscribe python mpi_example.py
         if [ $? -ne 0 ] ; then
           echo "hdf5 mpi test failed!"
           exit 1

--- a/include/mpi-compat.h
+++ b/include/mpi-compat.h
@@ -11,4 +11,9 @@ typedef void *PyMPI_MPI_Message;
 #define MPI_Message PyMPI_MPI_Message
 #endif
 
+#if (MPI_VERSION < 4) && !defined(PyMPI_HAVE_MPI_Session)
+typedef void *PyMPI_MPI_Session;
+#define MPI_Session PyMPI_MPI_Session
+#endif
+
 #endif/*MPI_COMPAT_H*/


### PR DESCRIPTION
As of 12 days ago, `mpi4py` has a new define `MPI_Session` which must be added to `include/mpi-compat.h` to prevent a `error: unknown type name ‘MPI_Session’` upon compiling `src/netCDF4/_netCDF4.c`. 

Also see the blame
https://github.com/mpi4py/mpi4py/blame/80c53a02c2f85c721c8c26b202a4ab0ed4ac02fc/src/mpi4py/include/mpi4py/mpi4py.h

