### PR TITLE
Added more descriptive error message if indexing with all False bool …

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,9 @@
 ==========================
  * Added ``netCDF4.__has_set_alignment__`` property to help identify if the
    underlying netcdf4 supports setting the HDF5 alignment.
+ * Slicing multi-dimensional variables with an all False boolean index array
+   now returns an empty numpy array (instead of raising an exception - issue #1197).
+   Behavior now consistent with numpy slicing.
 
  version 1.6.1 (tag v1.6.1rel)
 ==============================

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -4953,7 +4953,7 @@ rename a `Variable` attribute named `oldname` to `newname`."""
         # put_ind for this dimension is set to -1 by _StartCountStride.
         squeeze = data.ndim * [slice(None),]
         for i,n in enumerate(put_ind.shape[:-1]):
-            if n == 1 and put_ind[...,i].ravel()[0] == -1:
+            if n == 1 and put_ind.size > 0 and put_ind[...,i].ravel()[0] == -1:
                 squeeze[i] = 0
 
         # Reshape the arrays so we can iterate over them.

--- a/src/netCDF4/utils.py
+++ b/src/netCDF4/utils.py
@@ -461,7 +461,7 @@ def _out_array_shape(count):
     out = []
 
     for i, n in enumerate(s):
-        if n == 1:
+        if n == 1 and count.size > 0:
             c = count[..., i].ravel()[0] # All elements should be identical.
             out.append(c)
         else:

--- a/src/netCDF4/utils.py
+++ b/src/netCDF4/utils.py
@@ -208,6 +208,12 @@ def _StartCountStride(elem, shape, dimensions=None, grp=None, datashape=None,\
     if sum(1 for e in elem if e is Ellipsis) > 1:
         raise IndexError("At most one ellipsis allowed in a slicing expression")
 
+    # Check if elem is valid for bool array.
+    if type(elem) is np.ndarray:
+        if elem.dtype is np.dtype(bool) and np.logical_not(np.any(elem))
+            raise IndexError("All elements of bool indexing array are False. "
+                    "At least one element must be True to be valid.")
+
     # replace boolean arrays with sequences of integers.
     newElem = []
     IndexErrorMsg=\

--- a/src/netCDF4/utils.py
+++ b/src/netCDF4/utils.py
@@ -240,8 +240,8 @@ def _StartCountStride(elem, shape, dimensions=None, grp=None, datashape=None,\
         if np.iterable(ea) and ea.dtype.kind =='b':
             # check that boolean array is not all False.
             if not ea.any():
-                msg='Boolean index array is all False, at least one element must be True'
-                raise IndexError(msg)
+                msg='Boolean index array is all False. Empty array will be returned.'
+                warnings.warn(msg)
             # check that boolean array not too long
             if not unlim and shape[i] != len(ea):
                 msg="""

--- a/src/netCDF4/utils.py
+++ b/src/netCDF4/utils.py
@@ -208,12 +208,6 @@ def _StartCountStride(elem, shape, dimensions=None, grp=None, datashape=None,\
     if sum(1 for e in elem if e is Ellipsis) > 1:
         raise IndexError("At most one ellipsis allowed in a slicing expression")
 
-    # Check if elem is valid for bool array.
-    if type(elem) is np.ndarray:
-        if elem.dtype is np.dtype(bool) and np.logical_not(np.any(elem))
-            raise IndexError("All elements of bool indexing array are False. "
-                    "At least one element must be True to be valid.")
-
     # replace boolean arrays with sequences of integers.
     newElem = []
     IndexErrorMsg=\
@@ -244,6 +238,10 @@ def _StartCountStride(elem, shape, dimensions=None, grp=None, datashape=None,\
             unlim = False
         # convert boolean index to integer array.
         if np.iterable(ea) and ea.dtype.kind =='b':
+            # check that boolean array is not all False.
+            if not ea.any():
+                msg='Boolean index array is all False, at least one element must be True'
+                raise IndexError(msg)
             # check that boolean array not too long
             if not unlim and shape[i] != len(ea):
                 msg="""

--- a/test/tst_fancyslicing.py
+++ b/test/tst_fancyslicing.py
@@ -142,6 +142,11 @@ class VariablesTestCase(unittest.TestCase):
 
         assert_array_equal(v[0], self.data[0])
 
+        # slicing with all False booleans (PR #1197)
+        iby[:] = False
+        data = v[ibx,iby,ibz]
+        assert(data.size == 0)
+
         f.close()
 
     def test_set(self):


### PR DESCRIPTION
If one tries to load data using an all-False bool array, it returns an unhelpful error message that doesn't quite describe the problem.

```python
import numpy as np
import netCDF4 as nc
ncfile = nc.Dataset('example.nc', 'r')
get_this = np.zeros(ncfile.variables['pastr'].shape[0]).astype(bool)
data =  ncfile.variables['pastr'][get_this]
```

```
Traceback (most recent call last):
  File "testing.py", line 5, in <module>
    data =  ncfile.variables['pastr'][get_this]
  File "netCDF4/_netCDF4.pyx", line 4385, in netCDF4._netCDF4.Variable.__getitem__
  File "/usr/lib/python3/dist-packages/netCDF4/utils.py", line 467, in _out_array_shape
    c = count[..., i].ravel()[0] # All elements should be identical.
IndexError: index 0 is out of bounds for axis 0 with size 0
```

This pull request catches the case where an invalid all-False bool array is used to load data and adds a more descriptive error message.

Cheers,
Tam

