### PR TITLE
Define 'nc_inq_filter_avail' if szip support is enabled

### DIFF
--- a/include/netCDF4.pxi
+++ b/include/netCDF4.pxi
@@ -405,6 +405,7 @@ IF HAS_BZIP2_SUPPORT:
             H5Z_FILTER_BZIP2
         int nc_def_var_bzip2(int ncid, int varid, int level) nogil
         int nc_inq_var_bzip2(int ncid, int varid, int* hasfilterp, int *levelp) nogil
+        int nc_inq_filter_avail(int ncid, unsigned filterid) nogil
 
 IF HAS_BLOSC_SUPPORT:
     cdef extern from "netcdf_filter.h":
@@ -412,6 +413,7 @@ IF HAS_BLOSC_SUPPORT:
             H5Z_FILTER_BLOSC
         int nc_def_var_blosc(int ncid, int varid, unsigned subcompressor, unsigned level, unsigned blocksize, unsigned addshuffle) nogil
         int nc_inq_var_blosc(int ncid, int varid, int* hasfilterp, unsigned* subcompressorp, unsigned* levelp, unsigned* blocksizep, unsigned* addshufflep) nogil
+        int nc_inq_filter_avail(int ncid, unsigned filterid) nogil
 
 IF HAS_NC_OPEN_MEM:
     cdef extern from "netcdf_mem.h":

--- a/include/netCDF4.pxi
+++ b/include/netCDF4.pxi
@@ -388,6 +388,8 @@ IF HAS_SZIP_SUPPORT:
         int nc_inq_var_quantize(int ncid, int varid, int *quantize_modep, int *nsdp) nogil
         int nc_def_var_szip(int ncid, int varid, int options_mask, int pixels_per_bloc) nogil
         int nc_inq_var_szip(int ncid, int varid, int *options_maskp, int *pixels_per_blockp) nogil
+    cdef extern from "netcdf_filter.h":
+        int nc_inq_filter_avail(int ncid, unsigned filterid) nogil
 
 IF HAS_ZSTANDARD_SUPPORT:
     cdef extern from "netcdf_filter.h":


### PR DESCRIPTION
If both HAS_QUANTIZATION_SUPPORT and HAS_ZSTANDARD_SUPPORT are false, but HAS_SZIP_SUPPORT is enabled (as is happening on Ubuntu 22.04), the build fails due to nc_inq_filter_avail not being defined:

src/netCDF4/_netCDF4.pyx:3548:23: undeclared name not builtin: nc_inq_filter_avail

And a bunch of follow up errors:
src/netCDF4/_netCDF4.pyx:3548:42: Calling gil-requiring function not allowed without gil
src/netCDF4/_netCDF4.pyx:3548:23: Accessing Python global or builtin not allowed without gil
src/netCDF4/_netCDF4.pyx:3548:42: Constructing Python tuple not allowed without gil
src/netCDF4/_netCDF4.pyx:3548:47: Converting to Python object not allowed without gil
src/netCDF4/_netCDF4.pyx:3548:56: Converting to Python object not allowed without gil


Looking at the code a bit more, it seems like other filters like blosc and bzip2 might have the same issue, which has so far just never happened in practice. I added a commit for those as well.