### PR TITLE
add python_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -742,6 +742,7 @@ setup(name="netCDF4",
       package_dir={'':'src'},
       package_data={"netCDF4.plugins": ["lib__nc*"]},
       ext_modules=ext_modules,
+      python_requires=">=3.6",
       **setuptools_extra_kwargs)
 
 # remove plugin files copied from outside source tree


### PR DESCRIPTION
The classifiers are not really enforced, or used as package metadata, we need [python-requires](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#python-requires) to help folks use PEP440.