### PR TITLE
add pyproject.toml to ensure build deps are present at build time

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=41.2", "cython>=0.19", "oldest-supported-numpy"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import os.path as osp
 import shutil
 import configparser
 from setuptools import setup, Extension, find_namespace_packages
-from distutils.dist import Distribution
+from setuptools.dist import Distribution
 
 setuptools_extra_kwargs = {
     "install_requires": ["numpy>=1.9","cftime"],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ from distutils.dist import Distribution
 
 setuptools_extra_kwargs = {
     "install_requires": ["numpy>=1.9","cftime"],
-    "setup_requires": ['setuptools>=18.0', "cython>=0.19"],
     "entry_points": {
         'console_scripts': [
             'ncinfo = netCDF4.utils:ncinfo',


### PR DESCRIPTION
Closes #1207 and #1206.
