### PR TITLE
Drop Python 3.6, apply a few minor Python 3 styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ conda install -c conda-forge netCDF4
 * Clone GitHub repository (`git clone https://github.com/Unidata/netcdf4-python.git`)
 
 * Make sure [numpy](http://www.numpy.org/) and [Cython](http://cython.org/) are
-  installed and you have [Python](https://www.python.org) 3.6 or newer.
+  installed and you have [Python](https://www.python.org) 3.7 or newer.
 
 * Make sure [HDF5](http://www.h5py.org/) and netcdf-4 are installed, 
   and the `nc-config` utility is in your Unix PATH.

--- a/examples/bench_compress3.py
+++ b/examples/bench_compress3.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # benchmark reads and writes, with and without compression.
 # tests all four supported file formats.
 from numpy.random.mtrand import uniform

--- a/examples/bench_compress4.py
+++ b/examples/bench_compress4.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 # benchmark reads and writes, with and without compression.
 # tests all four supported file formats.
 from numpy.random.mtrand import uniform

--- a/examples/threaded_read.py
+++ b/examples/threaded_read.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from netCDF4 import Dataset
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 import numpy as np

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ open_kwargs = {'encoding': 'utf-8'}
 def check_hdf5version(hdf5_includedir):
     try:
         f = open(os.path.join(hdf5_includedir, 'H5public.h'), **open_kwargs)
-    except IOError:
+    except OSError:
         return None
     hdf5_version = None
     for line in f:
@@ -46,7 +46,7 @@ def get_hdf5_version(direc):
 def check_ifnetcdf4(netcdf4_includedir):
     try:
         f = open(os.path.join(netcdf4_includedir, 'netcdf.h'), **open_kwargs)
-    except IOError:
+    except OSError:
         return False
     isnetcdf4 = False
     for line in f:
@@ -76,7 +76,7 @@ def check_api(inc_dirs,netcdf_lib_version):
     for d in inc_dirs:
         try:
             f = open(os.path.join(d, 'netcdf.h'), **open_kwargs)
-        except IOError:
+        except OSError:
             continue
 
         has_nc_open_mem = os.path.exists(os.path.join(d, 'netcdf_mem.h'))
@@ -99,7 +99,7 @@ def check_api(inc_dirs,netcdf_lib_version):
         if has_nc_open_mem:
             try:
                 f = open(os.path.join(d, 'netcdf_mem.h'), **open_kwargs)
-            except IOError:
+            except OSError:
                 continue
             for line in f:
                 if line.startswith('EXTERNL int nc_create_mem'):
@@ -108,7 +108,7 @@ def check_api(inc_dirs,netcdf_lib_version):
         if has_nc_filter:
             try:
                 f = open(os.path.join(d, 'netcdf_filter.h'), **open_kwargs)
-            except IOError:
+            except OSError:
                 continue
             for line in f:
                 if line.startswith('EXTERNL int nc_def_var_zstandard'):
@@ -741,9 +741,11 @@ setup(name="netCDF4",
                 'meteorology', 'climate'],
       classifiers=["Development Status :: 3 - Alpha",
                    "Programming Language :: Python :: 3",
-                   "Programming Language :: Python :: 3.6",
                    "Programming Language :: Python :: 3.7",
                    "Programming Language :: Python :: 3.8",
+                   "Programming Language :: Python :: 3.9",
+                   "Programming Language :: Python :: 3.10",
+                   "Programming Language :: Python :: 3.11",
                    "Intended Audience :: Science/Research",
                    "License :: OSI Approved :: MIT License",
                    "Topic :: Software Development :: Libraries :: Python Modules",
@@ -753,7 +755,7 @@ setup(name="netCDF4",
       package_dir={'':'src'},
       package_data={"netCDF4.plugins": ["lib__nc*"]},
       ext_modules=ext_modules,
-      python_requires=">=3.6",
+      python_requires=">=3.7",
       **setuptools_extra_kwargs)
 
 # remove plugin files copied from outside source tree

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -32,7 +32,7 @@ types) are not supported.
 
  - Clone the
    [github repository](http://github.com/Unidata/netcdf4-python).
- - Make sure the dependencies are satisfied (Python 3.6 or later,
+ - Make sure the dependencies are satisfied (Python 3.7 or later,
    [numpy](http://numpy.scipy.org), 
    [Cython](http://cython.org),
    [cftime](https://github.com/Unidata/cftime),

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -1226,9 +1226,6 @@ from cpython.bytes cimport PyBytes_FromStringAndSize
 from .utils import (_StartCountStride, _quantize, _find_dim, _walk_grps,
                     _out_array_shape, _sortbylist, _tostr, _safecast, _is_int)
 import sys
-if sys.version_info[0:2] < (3, 7):
-    # Python 3.7+ guarantees order; older versions need OrderedDict
-    from collections import OrderedDict
 
 __version__ = "1.6.2"
 
@@ -1775,14 +1772,9 @@ cdef _get_types(group):
             ierr = nc_inq_typeids(_grpid, &ntypes, typeids)
         _ensure_nc_success(ierr)
     # create empty dictionary for CompoundType instances.
-    if sys.version_info[0:2] < (3, 7):
-        cmptypes = OrderedDict()
-        vltypes = OrderedDict()
-        enumtypes = OrderedDict()
-    else:
-        cmptypes = dict()
-        vltypes = dict()
-        enumtypes = dict()
+    cmptypes = dict()
+    vltypes = dict()
+    enumtypes = dict()
 
     if ntypes > 0:
         for n from 0 <= n < ntypes:
@@ -1839,10 +1831,7 @@ cdef _get_dims(group):
         ierr = nc_inq_ndims(_grpid, &numdims)
     _ensure_nc_success(ierr)
     # create empty dictionary for dimensions.
-    if sys.version_info[0:2] < (3, 7):
-        dimensions = OrderedDict()
-    else:
-        dimensions = dict()
+    dimensions = dict()
     if numdims > 0:
         dimids = <int *>malloc(sizeof(int) * numdims)
         if group.data_model == 'NETCDF4':
@@ -1873,10 +1862,7 @@ cdef _get_grps(group):
         ierr = nc_inq_grps(_grpid, &numgrps, NULL)
     _ensure_nc_success(ierr)
     # create dictionary containing `Group` instances for groups in this group
-    if sys.version_info[0:2] < (3, 7):
-        groups = OrderedDict()
-    else:
-        groups = dict()
+    groups = dict()
     if numgrps > 0:
         grpids = <int *>malloc(sizeof(int) * numgrps)
         with nogil:
@@ -1906,10 +1892,7 @@ cdef _get_vars(group):
         ierr = nc_inq_nvars(_grpid, &numvars)
     _ensure_nc_success(ierr, err_cls=AttributeError)
     # create empty dictionary for variables.
-    if sys.version_info[0:2] < (3, 7):
-        variables = OrderedDict()
-    else:
-        variables = dict()
+    variables = dict()
     if numvars > 0:
         # get variable ids.
         varids = <int *>malloc(sizeof(int) * numvars)
@@ -2488,10 +2471,7 @@ strings.
         if self.data_model == 'NETCDF4':
             self.groups = _get_grps(self)
         else:
-            if sys.version_info[0:2] < (3, 7):
-                self.groups = OrderedDict()
-            else:
-                self.groups = dict()
+            self.groups = dict()
 
     # these allow Dataset objects to be used via a "with" statement.
     def __enter__(self):
@@ -3128,11 +3108,7 @@ attributes."""
                 values = []
                 for name in names:
                     values.append(_get_att(self, NC_GLOBAL, name))
-                gen = zip(names, values)
-                if sys.version_info[0:2] < (3, 7):
-                    return OrderedDict(gen)
-                else:
-                    return dict(gen)
+                return dict(zip(names, values))
             else:
                 raise AttributeError
         elif name in _private_atts:
@@ -3621,20 +3597,12 @@ Additional read-only class variables:
             with nogil:
                 ierr = nc_def_grp(grpid, groupname, &self._grpid)
             _ensure_nc_success(ierr)
-            if sys.version_info[0:2] < (3, 7):
-                self.cmptypes = OrderedDict()
-                self.vltypes = OrderedDict()
-                self.enumtypes = OrderedDict()
-                self.dimensions = OrderedDict()
-                self.variables = OrderedDict()
-                self.groups = OrderedDict()
-            else:
-                self.cmptypes = dict()
-                self.vltypes = dict()
-                self.enumtypes = dict()
-                self.dimensions = dict()
-                self.variables = dict()
-                self.groups = dict()
+            self.cmptypes = dict()
+            self.vltypes = dict()
+            self.enumtypes = dict()
+            self.dimensions = dict()
+            self.variables = dict()
+            self.groups = dict()
 
 
     def close(self):
@@ -4910,11 +4878,7 @@ details."""
                 values = []
                 for name in names:
                     values.append(_get_att(self._grp, self._varid, name))
-                gen = zip(names, values)
-                if sys.version_info[0:2] < (3, 7):
-                    return OrderedDict(gen)
-                else:
-                    return dict(gen)
+                return dict(zip(names, values))
 
             else:
                 raise AttributeError

--- a/src/netCDF4/utils.py
+++ b/src/netCDF4/utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import numpy as np
 from numpy import ma
@@ -578,7 +576,7 @@ def _nc4tonc3(filename4,filename3,clobber=False,nchunk=10,quiet=False,format='NE
 
     ncfile4 = Dataset(filename4,'r')
     if ncfile4.file_format != 'NETCDF4_CLASSIC':
-        raise IOError('input file must be in NETCDF4_CLASSIC format')
+        raise OSError('input file must be in NETCDF4_CLASSIC format')
     ncfile3 = Dataset(filename3,'w',clobber=clobber,format=format)
     # create dimensions. Check for unlimited dim.
     unlimdimname = False

--- a/test/tst_atts.py
+++ b/test/tst_atts.py
@@ -115,7 +115,7 @@ class VariablesTestCase(unittest.TestCase):
             f.charatt = 'foo' # will be written as NC_CHAR
             f.setncattr_string('stringatt','bar') # NC_STRING
             f.cafe = 'caf\xe9' # NC_STRING
-            f.batt = 'caf\xe9'.encode('utf-8') #NC_CHAR
+            f.batt = 'caf\xe9'.encode() #NC_CHAR
             v.setncattr_string('stringatt','bar') # NC_STRING
             # issue #882 - provide an option to always string attribute
             # as NC_STRINGs. Testing various approaches to setting text attributes...
@@ -123,7 +123,7 @@ class VariablesTestCase(unittest.TestCase):
             f.stringatt_ncstr = 'foo' # will now be written as NC_STRING
             f.setncattr_string('stringatt_ncstr','bar') # NC_STRING anyway
             f.caf_ncstr = 'caf\xe9' # NC_STRING anyway
-            f.bat_ncstr = 'caf\xe9'.encode('utf-8') # now NC_STRING
+            f.bat_ncstr = 'caf\xe9'.encode() # now NC_STRING
             g.stratt_ncstr = STRATT # now NC_STRING
             #g.renameAttribute('stratt_tmp','stratt_ncstr')
             v.setncattr_string('stringatt_ncstr','bar') # NC_STRING anyway


### PR DESCRIPTION
Python 3.6 is no longer supported ([PEP 494](https://peps.python.org/pep-0494/)), and testing with that version was recently removed.

Provisionally, the minimum Python version is set to 3.7. However, it is recommended to push this to 3.8 to align with [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html) for NumPy, which has been 3.8+ for nearly a year. Any thoughts on 3.7 or 3.8 as a minimum?

---
Other minor Python 3 styles:

- the `from __future__ import` statements were relevant for Python 2
- `IOError` is an alias of `OSError` since [PEP 3151](https://peps.python.org/pep-3151/)
- the default for `.encode()` is already utf-8, so does not need to be specified