### PR TITLE
Re-add project name to setup.py for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -717,6 +717,7 @@ else:
 
 # See pyproject.toml for project metadata
 setup(
+    name="netCDF4",  # need by GitHub dependency graph
     version=extract_version(netcdf4_src_pyx),
     ext_modules=ext_modules,
 )


### PR DESCRIPTION
As suggested [here](https://github.com/Unidata/netcdf4-python/pull/1216#discussion_r1029540964) by @ocefpaf, the "name" metadata needs to be present in setup.py for GitHub's [dependency graph](https://github.com/Unidata/netcdf4-python/network/dependents), which currently has "We haven’t found any dependents for this repository yet."