### PR TITLE
cimport numpy and call numpy.import_array()

### DIFF
--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -1233,6 +1233,7 @@ __version__ = "1.6.3"
 import posixpath
 from cftime import date2num, num2date, date2index
 import numpy
+cimport numpy
 import weakref
 import warnings
 import subprocess
@@ -1242,7 +1243,7 @@ from glob import glob
 from numpy import ma
 from libc.string cimport memcpy, memset
 from libc.stdlib cimport malloc, free
-import_array()
+numpy.import_array()
 include "constants.pyx"
 include "membuf.pyx"
 include "netCDF4.pxi"
@@ -1468,8 +1469,8 @@ default_fillvals = {#'S1':NC_FILL_CHAR,
                      'f8':NC_FILL_DOUBLE}
 
 # logical for native endian type.
-is_native_little = numpy.dtype('<f4').byteorder == '='
-is_native_big = numpy.dtype('>f4').byteorder == '='
+is_native_little = numpy.dtype('<f4').byteorder == c'='
+is_native_big = numpy.dtype('>f4').byteorder == c'='
 
 # hard code these here, instead of importing from netcdf.h
 # so it will compile with versions <= 4.2.


### PR DESCRIPTION
Hi there,

This pr slightly modifies the way to call import_array() according to cython's document

otherwise the generated code can trigger
```
src/netCDF4/_netCDF4.c:87070:3: error: incompatible pointer to integer conversion returning 'void *' from a function with result type 'int' [-Wint-conversion]
  import_array();
/usr/lib/python3.10/site-packages/numpy/core/include/numpy/__multiarray_api.h:155
3:151: note: expanded from macro 'import_array'                                  
#define import_array() {if (_import_array() < 0) {PyErr_Print(); PyErr_SetString(
PyExc_ImportError, "numpy.core.multiarray failed to import"); return NULL; } }
                                                                                 
                                                                     ^~~~
/usr/lib/llvm/15/bin/../../../../lib/clang/15.0.6/include/stddef.h:89:16: note: e
xpanded from macro 'NULL'
#  define NULL ((void*)0)
               ^~~~~~~~~~
3 warnings and 1 error generated.
```

clang-15 makes int-conversion a default error

Appreciate if anyone could review this.