### PR TITLE
Implement lru_cache for get_variables_by_attributes

### DIFF
--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -2622,7 +2622,9 @@ Is the Dataset open or closed?
         return bool(self._isopen)
 
     def __dealloc__(self):
-        # close file when there are no references to object left
+        # close file when there are no references to object left and clear the cache.
+        if self.get_variables_by_attributes:
+            self.get_variables_by_attributes.cache_clear()
         if self._isopen:
            self._close(False)
 

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -2100,7 +2100,7 @@ strings.
     cdef Py_buffer _buffer
     cdef public groups, dimensions, variables, disk_format, path, parent,\
     file_format, data_model, cmptypes, vltypes, enumtypes,  __orthogonal_indexing__, \
-    keepweakref, _ncstring_attrs__, get_variables_by_attributes
+    keepweakref, _ncstring_attrs__
 
     def __init__(self, filename, mode='r', clobber=True, format='NETCDF4',
                      diskless=False, persist=False, keepweakref=False,
@@ -2211,10 +2211,6 @@ strings.
             cdef MPI_Info mpiinfo
 
         memset(&self._buffer, 0, sizeof(self._buffer))
-
-        self.get_variables_by_attributes = functools.lru_cache(maxsize=128)(
-            self._get_variables_by_attributes_uncached,
-        )
 
         # flag to indicate that Variables in this Dataset support orthogonal indexing.
         self.__orthogonal_indexing__ = True
@@ -3340,7 +3336,8 @@ of existing (sub-) groups and their variables.
             for group in groups:
                 group.set_ncstring_attrs(value) # recurse into subgroups...
 
-    def _get_variables_by_attributes_uncached(self, **kwargs):
+    @functools.lru_cache(maxsize=128)
+    def get_variables_by_attributes(self, **kwargs):
         """
 **`get_variables_by_attributes(self, **kwargs)`**
 
@@ -6919,9 +6916,6 @@ Example usage (See `MFDataset.__init__` for more details):
             if name == 'groups': return self._grps
         else:
             return Dataset.__getattribute__(self, name)
-
-    def get_variables_by_attributes(self, **kwargs):
-        return Dataset._get_variables_by_attributes_uncached(self, **kwargs)
 
     def ncattrs(self):
         """

--- a/test/run_all.py
+++ b/test/run_all.py
@@ -58,7 +58,7 @@ if os.getenv('NO_CDL'):
     sys.stdout.write('not running tst_cdl.py ...\n')
 
 # Don't run computationally intensive test
-if os.getenv('MEMORY_LEAK_TEST'):
+if not os.getenv('MEMORY_LEAK_TEST'):
     test_files.remove('tst_multiple_open_close.py');
     sys.stdout.write('not running tst_multiple_open_close.py ...\n')
 

--- a/test/run_all.py
+++ b/test/run_all.py
@@ -57,6 +57,11 @@ if os.getenv('NO_CDL'):
     test_files.remove('tst_cdl.py');
     sys.stdout.write('not running tst_cdl.py ...\n')
 
+# Don't run computationally intensive test
+if os.getenv('MEMORY_LEAK_TEST'):
+    test_files.remove('tst_multiple_open_close.py');
+    sys.stdout.write('not running tst_multiple_open_close.py ...\n')
+
 # Build the test suite from the tests found in the test files.
 testsuite = unittest.TestSuite()
 for f in test_files:

--- a/test/tst_multiple_open_close.py
+++ b/test/tst_multiple_open_close.py
@@ -9,9 +9,9 @@ class MultipleVariablesByAttributesCallsTests(unittest.TestCase):
 
     def test_multiple_calls(self):
         netcdf_file = os.path.join(os.path.dirname(__file__), "netcdf_dummy_file.nc")
+        tracemalloc.start()
         snapshot = tracemalloc.take_snapshot()
 
-        # k_times = 1000_000
         k_times = 10
         for _k in range(k_times):
             nc = netCDF4.Dataset(netcdf_file)
@@ -41,11 +41,10 @@ class MultipleVariablesByAttributesCallsTests(unittest.TestCase):
             self.assertEqual(len(vs), 1)
             nc.close()
         stats = tracemalloc.take_snapshot().compare_to(snapshot, 'filename')
+        tracemalloc.stop()
         print("[ Top 10 differences ]")
         for stat in stats[:10]:
             print(stat)
 
-if __name__ == '__main__':
-    tracemalloc.start()
+if __name__ == '__main__':    
     unittest.main()
-    tracemalloc.stop()

--- a/test/tst_multiple_open_close.py
+++ b/test/tst_multiple_open_close.py
@@ -1,0 +1,51 @@
+import os
+import tracemalloc
+import unittest
+
+import netCDF4
+
+class MultipleVariablesByAttributesCallsTests(unittest.TestCase):
+
+
+    def test_multiple_calls(self):
+        netcdf_file = os.path.join(os.path.dirname(__file__), "netcdf_dummy_file.nc")
+        snapshot = tracemalloc.take_snapshot()
+
+        # k_times = 1000_000
+        k_times = 10
+        for _k in range(k_times):
+            nc = netCDF4.Dataset(netcdf_file)
+            
+            vs = nc.get_variables_by_attributes(axis='Z')
+            self.assertEqual(len(vs), 1)
+            
+            vs = nc.get_variables_by_attributes(units='m/s')
+            self.assertEqual(len(vs), 4)
+
+            vs = nc.get_variables_by_attributes(axis='Z', units='m')
+            self.assertEqual(len(vs), 1)
+            
+            vs = nc.get_variables_by_attributes(axis=lambda v: v in ['X', 'Y', 'Z', 'T'])
+            self.assertEqual(len(vs), 1)
+
+            vs = nc.get_variables_by_attributes(grid_mapping=lambda v: v is not None)
+            self.assertEqual(len(vs), 12)
+
+            vs = nc.get_variables_by_attributes(grid_mapping=lambda v: v is not None, long_name=lambda v: v is not None and 'Upward (w) velocity' in v)
+            self.assertEqual(len(vs), 1)
+
+            vs = nc.get_variables_by_attributes(units='m/s', grid_mapping=lambda v: v is not None)
+            self.assertEqual(len(vs), 4)
+
+            vs = nc.get_variables_by_attributes(grid_mapping=lambda v: v is not None, long_name='Upward (w) velocity')
+            self.assertEqual(len(vs), 1)
+            nc.close()
+        stats = tracemalloc.take_snapshot().compare_to(snapshot, 'filename')
+        print("[ Top 10 differences ]")
+        for stat in stats[:10]:
+            print(stat)
+
+if __name__ == '__main__':
+    tracemalloc.start()
+    unittest.main()
+    tracemalloc.stop()


### PR DESCRIPTION
Still a work in progress and should be reviewed after #1252.

I'm not sure this is the best approach b/c the `Dataset` class will get a nice cached version of it without the memory leak caused if we use the decorator directly. However, that means the `MFDataset` will get the uncached one. We can do the same we did for `Dataset` in this PR to implement a cached version for `MFDataset` but I'm not sure that is worth the extra code (burden).