### PR TITLE
Re-arrange pyproject.toml readme to be compatible with older parsers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,14 +9,6 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "netCDF4"
 description = "Provides an object-oriented python interface to the netCDF version 4 library"
-readme = {text = """\
-netCDF version 4 has many features not found in earlier versions of the library,
-such as hierarchical groups, zlib compression, multiple unlimited dimensions,
-and new data types.  It is implemented on top of HDF5.  This module implements
-most of the new features, and can read and write netCDF files compatible with
-older versions of the library.  The API is modelled after Scientific.IO.NetCDF,
-and should be familiar to users of that module.
-""", content-type = "text/x-rst"}
 authors = [
   {name = "Jeff Whitaker", email = "jeffrey.s.whitaker@noaa.gov"},
 ]
@@ -46,6 +38,17 @@ dependencies = [
     "numpy",
 ]
 dynamic = ["version"]
+
+[project.readme]
+text = """\
+netCDF version 4 has many features not found in earlier versions of the library,
+such as hierarchical groups, zlib compression, multiple unlimited dimensions,
+and new data types.  It is implemented on top of HDF5.  This module implements
+most of the new features, and can read and write netCDF files compatible with
+older versions of the library.  The API is modelled after Scientific.IO.NetCDF,
+and should be familiar to users of that module.
+"""
+content-type = "text/x-rst"
 
 [project.scripts]
 nc3tonc4 = "netCDF4.utils:nc3tonc4"


### PR DESCRIPTION
The content is the same, but re-arrange the items in `pyproject.toml` to work with older TOML parsers.

Closes #1265