### PR TITLE
Try to improve error messages when creating `Variable`s

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
  version 1.6.5 (not yet released)
 ===============================
  * fix for issue #1271 (mask ignored if bool MA assinged to uint8 var)
+ * include information on specific object when reporting errors from netcdf-c
 
  version 1.6.4 (tag v1.6.4rel)
 ===============================

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -2018,14 +2018,16 @@ cdef _get_vars(group):
 
 cdef _ensure_nc_success(ierr, err_cls=RuntimeError, filename=None):
     # print netcdf error message, raise error.
-    if ierr != NC_NOERR:
-        err_str = (<char *>nc_strerror(ierr)).decode('ascii')
-        if issubclass(err_cls, OSError):
-            if isinstance(filename, bytes):
-                filename = filename.decode()
-            raise err_cls(ierr, err_str, filename)
-        else:
-            raise err_cls(err_str)
+    if ierr == NC_NOERR:
+        return
+
+    err_str = (<char *>nc_strerror(ierr)).decode('ascii')
+    if issubclass(err_cls, OSError):
+        if isinstance(filename, bytes):
+            filename = filename.decode()
+        raise err_cls(ierr, err_str, filename)
+
+    raise err_cls(err_str)
 
 # these are class attributes that
 # only exist at the python level (not in the netCDF file).


### PR DESCRIPTION
Error messages are currently reported directly from the netcdf-C error string, which doesn't include information about the specific object. This can make debugging awkward or painful. This PR simply includes the variable and group names in error messages arising from `Variable.__init__`.

Minimal example:

```python
import netCDF4

with netCDF4.Dataset("badname.nc", "w", format="NETCDF4") as f:
    time = f.createDimension("time", None)
    g = f.createVariable("badname ", "i4", ("time",))
```

Error without this PR:

```
RuntimeError: NetCDF: Name contains illegal characters
```

With this PR:

```
RuntimeError: NetCDF: Name contains illegal characters: (variable 'badname ', group '/')
```

Exact format could be tweaked and used in more places.