### PR TITLE
Remove deprecated Cython `IF`, `DEF`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist/
 netCDF4/_netCDF4.c
 netCDF4/*.so
 include/constants.pyx
+include/parallel_support_imports.pxi
 netcdftime/_netcdftime.c
 venv/
 .eggs/

--- a/include/mpi-compat.h
+++ b/include/mpi-compat.h
@@ -4,6 +4,10 @@
 #ifndef MPI_COMPAT_H
 #define MPI_COMPAT_H
 
+#include "netcdf-compat.h"
+
+#if HAS_PARALLEL_SUPPORT
+
 #include <mpi.h>
 
 #if (MPI_VERSION < 3) && !defined(PyMPI_HAVE_MPI_Message)
@@ -15,5 +19,7 @@ typedef void *PyMPI_MPI_Message;
 typedef void *PyMPI_MPI_Session;
 #define MPI_Session PyMPI_MPI_Session
 #endif
+
+#endif /* HAS_PARALLEL_SUPPORT */
 
 #endif/*MPI_COMPAT_H*/

--- a/include/netCDF4.pxi
+++ b/include/netCDF4.pxi
@@ -358,72 +358,13 @@ cdef extern from "netcdf.h":
     int nc_set_chunk_cache(size_t size, size_t nelems, float preemption) nogil
     int nc_set_var_chunk_cache(int ncid, int varid, size_t size, size_t nelems, float preemption) nogil
     int nc_get_var_chunk_cache(int ncid, int varid, size_t *sizep, size_t *nelemsp, float *preemptionp) nogil
-    int nc_rename_grp(int grpid, char *name) nogil
     int nc_def_enum(int ncid, nc_type base_typeid, char *name, nc_type *typeidp) nogil
     int nc_insert_enum(int ncid, nc_type xtype, char *name, void *value) nogil
     int nc_inq_enum(int ncid, nc_type xtype, char *name, nc_type *base_nc_typep,\
 	    size_t *base_sizep, size_t *num_membersp) nogil
     int nc_inq_enum_member(int ncid, nc_type xtype, int idx, char *name, void *value) nogil
-
     int nc_inq_enum_ident(int ncid, nc_type xtype, long long value, char *identifier) nogil
-    int nc_rc_set(char* key, char* value) nogil
 
-IF HAS_QUANTIZATION_SUPPORT:
-    cdef extern from "netcdf.h":
-        cdef enum:
-            NC_NOQUANTIZE
-            NC_QUANTIZE_BITGROOM
-            NC_QUANTIZE_GRANULARBR
-            NC_QUANTIZE_BITROUND
-        int nc_def_var_quantize(int ncid, int varid, int quantize_mode, int nsd) nogil
-        int nc_inq_var_quantize(int ncid, int varid, int *quantize_modep, int *nsdp) nogil
-
-IF HAS_NCFILTER:
-    cdef extern from "netcdf_filter.h":
-        int nc_inq_filter_avail(int ncid, unsigned filterid) nogil
-
-IF HAS_SZIP_SUPPORT:
-    cdef extern from "netcdf.h":
-        cdef enum:
-            H5Z_FILTER_SZIP
-        int nc_def_var_quantize(int ncid, int varid, int quantize_mode, int nsd) nogil
-        int nc_inq_var_quantize(int ncid, int varid, int *quantize_modep, int *nsdp) nogil
-        int nc_def_var_szip(int ncid, int varid, int options_mask, int pixels_per_bloc) nogil
-        int nc_inq_var_szip(int ncid, int varid, int *options_maskp, int *pixels_per_blockp) nogil
-
-IF HAS_ZSTANDARD_SUPPORT:
-    cdef extern from "netcdf_filter.h":
-        cdef enum:
-            H5Z_FILTER_ZSTD
-        int nc_def_var_zstandard(int ncid, int varid, int level) nogil
-        int nc_inq_var_zstandard(int ncid, int varid, int* hasfilterp, int *levelp) nogil
-
-IF HAS_BZIP2_SUPPORT:
-    cdef extern from "netcdf_filter.h":
-        cdef enum:
-            H5Z_FILTER_BZIP2
-        int nc_def_var_bzip2(int ncid, int varid, int level) nogil
-        int nc_inq_var_bzip2(int ncid, int varid, int* hasfilterp, int *levelp) nogil
-
-IF HAS_BLOSC_SUPPORT:
-    cdef extern from "netcdf_filter.h":
-        cdef enum:
-            H5Z_FILTER_BLOSC
-        int nc_def_var_blosc(int ncid, int varid, unsigned subcompressor, unsigned level, unsigned blocksize, unsigned addshuffle) nogil
-        int nc_inq_var_blosc(int ncid, int varid, int* hasfilterp, unsigned* subcompressorp, unsigned* levelp, unsigned* blocksizep, unsigned* addshufflep) nogil
-
-IF HAS_NC_OPEN_MEM:
-    cdef extern from "netcdf_mem.h":
-        int nc_open_mem(const char *path, int mode, size_t size, void* memory, int *ncidp) nogil
-
-IF HAS_NC_CREATE_MEM:
-    cdef extern from "netcdf_mem.h":
-        int nc_create_mem(const char *path, int mode, size_t initialize, int *ncidp) nogil
-        ctypedef struct NC_memio:
-            size_t size
-            void* memory
-            int flags
-        int nc_close_memio(int ncid, NC_memio* info) nogil
 
 IF HAS_PARALLEL4_SUPPORT or HAS_PNETCDF_SUPPORT:
     cdef extern from "mpi-compat.h": pass
@@ -442,11 +383,6 @@ IF HAS_PARALLEL4_SUPPORT or HAS_PNETCDF_SUPPORT:
             NC_MPIPOSIX
             NC_PNETCDF
 
-IF HAS_SET_ALIGNMENT:
-    cdef extern from "netcdf.h":
-        int nc_set_alignment(int threshold, int alignment)
-        int nc_get_alignment(int *threshold, int *alignment)
-
 # taken from numpy.pxi in numpy 1.0rc2.
 cdef extern from "numpy/arrayobject.h":
     ctypedef int npy_intp 
@@ -459,3 +395,72 @@ cdef extern from "numpy/arrayobject.h":
     char* PyArray_BYTES(ndarray) nogil
     npy_intp* PyArray_STRIDES(ndarray) nogil
     void import_array()
+
+
+# Compatibility shims
+cdef extern from "netcdf-compat.h":
+    int nc_rename_grp(int grpid, char *name) nogil
+    int nc_set_alignment(int threshold, int alignment)
+    int nc_get_alignment(int *threshold, int *alignment)
+    int nc_rc_set(char* key, char* value) nogil
+
+    int nc_open_mem(const char *path, int mode, size_t size, void* memory, int *ncidp) nogil
+    int nc_create_mem(const char *path, int mode, size_t initialize, int *ncidp) nogil
+    ctypedef struct NC_memio:
+        size_t size
+        void* memory
+        int flags
+    int nc_close_memio(int ncid, NC_memio* info) nogil
+
+    # Quantize shims
+    int nc_def_var_quantize(int ncid, int varid, int quantize_mode, int nsd) nogil
+    int nc_inq_var_quantize(int ncid, int varid, int *quantize_modep, int *nsdp) nogil
+
+    # Filter shims
+    int nc_inq_filter_avail(int ncid, unsigned filterid) nogil
+
+    int nc_def_var_szip(int ncid, int varid, int options_mask,
+                        int pixels_per_bloc) nogil
+    int nc_inq_var_szip(int ncid, int varid, int *options_maskp,
+                        int *pixels_per_blockp) nogil
+
+    int nc_def_var_zstandard(int ncid, int varid, int level) nogil
+    int nc_inq_var_zstandard(int ncid, int varid, int* hasfilterp, int *levelp) nogil
+
+    int nc_def_var_bzip2(int ncid, int varid, int level) nogil
+    int nc_inq_var_bzip2(int ncid, int varid, int* hasfilterp, int *levelp) nogil
+
+    int nc_def_var_blosc(int ncid, int varid, unsigned subcompressor, unsigned level,
+                         unsigned blocksize, unsigned addshuffle) nogil
+    int nc_inq_var_blosc(int ncid, int varid, int* hasfilterp, unsigned* subcompressorp,
+                         unsigned* levelp, unsigned* blocksizep,
+                         unsigned* addshufflep) nogil
+
+    cdef enum:
+        HAS_RENAME_GRP
+        HAS_NC_INQ_PATH
+        HAS_NC_INQ_FORMAT_EXTENDED
+        HAS_NC_OPEN_MEM
+        HAS_NC_CREATE_MEM
+        HAS_CDF5_FORMAT
+        HAS_PARALLEL_SUPPORT
+        HAS_PARALLEL4_SUPPORT
+        HAS_PNETCDF_SUPPORT
+        HAS_SZIP_SUPPORT
+        HAS_QUANTIZATION_SUPPORT
+        HAS_ZSTANDARD_SUPPORT
+        HAS_BZIP2_SUPPORT
+        HAS_BLOSC_SUPPORT
+        HAS_SET_ALIGNMENT
+        HAS_NCFILTER
+        HAS_NCRCSET
+
+        NC_NOQUANTIZE
+        NC_QUANTIZE_BITGROOM
+        NC_QUANTIZE_GRANULARBR
+        NC_QUANTIZE_BITROUND
+
+        H5Z_FILTER_SZIP
+        H5Z_FILTER_ZSTD
+        H5Z_FILTER_BZIP2
+        H5Z_FILTER_BLOSC

--- a/include/netCDF4.pxi
+++ b/include/netCDF4.pxi
@@ -368,20 +368,7 @@ cdef extern from "netcdf.h":
 
 IF HAS_PARALLEL4_SUPPORT or HAS_PNETCDF_SUPPORT:
     cdef extern from "mpi-compat.h": pass
-    cdef extern from "netcdf_par.h":
-        ctypedef int MPI_Comm
-        ctypedef int MPI_Info
-        int nc_create_par(char *path, int cmode, MPI_Comm comm, MPI_Info info, int *ncidp) nogil
-        int nc_open_par(char *path, int mode, MPI_Comm comm, MPI_Info info, int *ncidp) nogil
-        int nc_var_par_access(int ncid, int varid, int par_access) nogil
-        cdef enum:
-            NC_COLLECTIVE
-            NC_INDEPENDENT
-    cdef extern from "netcdf.h":
-        cdef enum:
-            NC_MPIIO
-            NC_MPIPOSIX
-            NC_PNETCDF
+
 
 # taken from numpy.pxi in numpy 1.0rc2.
 cdef extern from "numpy/arrayobject.h":
@@ -436,6 +423,13 @@ cdef extern from "netcdf-compat.h":
                          unsigned* levelp, unsigned* blocksizep,
                          unsigned* addshufflep) nogil
 
+    # Parallel shims
+    ctypedef int MPI_Comm
+    ctypedef int MPI_Info
+    int nc_create_par(char *path, int cmode, MPI_Comm comm, MPI_Info info, int *ncidp) nogil
+    int nc_open_par(char *path, int mode, MPI_Comm comm, MPI_Info info, int *ncidp) nogil
+    int nc_var_par_access(int ncid, int varid, int par_access) nogil
+
     cdef enum:
         HAS_RENAME_GRP
         HAS_NC_INQ_PATH
@@ -464,3 +458,10 @@ cdef extern from "netcdf-compat.h":
         H5Z_FILTER_ZSTD
         H5Z_FILTER_BZIP2
         H5Z_FILTER_BLOSC
+
+        NC_COLLECTIVE
+        NC_INDEPENDENT
+
+        NC_MPIIO
+        NC_MPIPOSIX
+        NC_PNETCDF

--- a/include/netCDF4.pxi
+++ b/include/netCDF4.pxi
@@ -366,7 +366,7 @@ cdef extern from "netcdf.h":
     int nc_inq_enum_ident(int ncid, nc_type xtype, long long value, char *identifier) nogil
 
 
-IF HAS_PARALLEL4_SUPPORT or HAS_PNETCDF_SUPPORT:
+IF HAS_PARALLEL_SUPPORT:
     cdef extern from "mpi-compat.h": pass
 
 

--- a/include/netCDF4.pxi
+++ b/include/netCDF4.pxi
@@ -366,8 +366,8 @@ cdef extern from "netcdf.h":
     int nc_inq_enum_ident(int ncid, nc_type xtype, long long value, char *identifier) nogil
 
 
-IF HAS_PARALLEL_SUPPORT:
-    cdef extern from "mpi-compat.h": pass
+cdef extern from "mpi-compat.h":
+    pass
 
 
 # taken from numpy.pxi in numpy 1.0rc2.

--- a/include/netcdf-compat.h
+++ b/include/netcdf-compat.h
@@ -1,3 +1,6 @@
+#ifndef NETCDF_COMPAT_H
+#define NETCDF_COMPAT_H
+
 #include <netcdf.h>
 #include <netcdf_meta.h>
 
@@ -192,3 +195,5 @@ static inline int nc_inq_var_blosc(int ncid, int varid, int* hasfilterp, unsigne
 # endif
 #define HAS_BLOSC_SUPPORT 0
 #endif
+
+#endif /* NETCDF_COMPAT_H */

--- a/include/netcdf-compat.h
+++ b/include/netcdf-compat.h
@@ -1,0 +1,180 @@
+#include <netcdf.h>
+#include <netcdf_meta.h>
+
+#define NC_VERSION_EQ(MAJOR, MINOR, PATCH) \
+  ((NC_VERSION_MAJOR == (MAJOR)) && \
+   (NC_VERSION_MINOR == (MINOR)) && \
+   (NC_VERSION_PATCH == (PATCH)))
+
+#define NC_VERSION_GT(MAJOR, MINOR, PATCH) \
+  (NC_VERSION_MAJOR > (MAJOR) || \
+   (NC_VERSION_MAJOR == (MAJOR) && \
+    (NC_VERSION_MINOR > (MINOR) || \
+     (NC_VERSION_MINOR == (MINOR) && \
+      (NC_VERSION_PATCH > (PATCH))))))
+
+#define NC_VERSION_GE(MAJOR, MINOR, PATCH) \
+  (NC_VERSION_GT(MAJOR, MINOR, PATCH) || \
+   NC_VERSION_EQ(MAJOR, MINOR, PATCH))
+
+#if NC_VERSION_GE(4, 3, 0)
+#define HAS_RENAME_GRP 1
+#else
+#define HAS_RENAME_GRP 0
+static inline int nc_rename_grp(int grpid, const char* name) { return NC_EINVAL; }
+#endif
+
+#if NC_VERSION_GE(4, 1, 2)
+#define HAS_NC_INQ_PATH 1
+#else
+#define HAS_NC_INQ_PATH 0
+static inline int nc_inq_path(int ncid, size_t *pathlen, char *path) {
+  *pathlen = 0; *path = "\0"; return NC_EINVAL;
+}
+#endif
+
+#if NC_VERSION_GE(4, 3, 1)
+#define HAS_NC_INQ_FORMAT_EXTENDED 1
+#else
+#define HAS_NC_INQ_FORMAT_EXTENDED 0
+static inline int nc_inq_format_extended(int ncid, int *formatp, int* modep) {
+  *formatp = 0; *modep = 0; return NC_EINVAL;
+}
+#endif
+
+#if NC_VERSION_GE(4, 9, 0)
+#define HAS_SET_ALIGNMENT 1
+#else
+#define HAS_SET_ALIGNMENT 0
+static inline int nc_set_alignment(int threshold, int alignment) { return NC_EINVAL; }
+static inline int nc_get_alignment(int* thresholdp, int* alignmentp) {
+  *thresholdp = 0; *alignmentp = 0; return NC_EINVAL;
+}
+#endif
+
+#if NC_VERSION_GE(4, 9, 0)
+#define HAS_NCRCSET 1
+#else
+#define HAS_NCRCSET 0
+static inline int nc_rc_set(const char* key, const char* value) { return NC_EINVAL; }
+#endif
+
+#if NC_VERSION_GE(4, 4, 0)
+#include <netcdf_mem.h>
+#define HAS_NC_OPEN_MEM 1
+#else
+#define HAS_NC_OPEN_MEM 0
+static inline int nc_open_mem(const char *path, int mode, size_t size, void* memory, int *ncidp) { return NC_EINVAL; }
+#endif
+
+#if NC_VERSION_GE(4, 6, 2)
+#define HAS_NC_CREATE_MEM 1
+#else
+#define HAS_NC_CREATE_MEM 0
+static inline int nc_create_mem(const char *path, int mode, size_t initialize, int *ncidp) { return NC_EINVAL; }
+typedef struct NC_memio {
+  size_t size;
+  void* memory;
+  int flags;
+} NC_memio;
+static inline int nc_close_memio(int ncid, NC_memio* info) { return NC_EINVAL; }
+#endif
+
+#if defined(NC_HAS_CDF5) && NC_HAS_CDF5
+#define HAS_CDF5_FORMAT 1
+#else
+# ifndef NC_HAS_CDF5
+# define NC_64BIT_DATA    0x0020
+# define NC_CDF5          NC_64BIT_DATA
+# define NC_FORMAT_64BIT_OFFSET    (2)
+# define NC_FORMAT_64BIT_DATA      (5)
+# endif
+#define HAS_CDF5_FORMAT 0
+#endif
+
+#if defined(NC_HAS_PARALLEL) && NC_HAS_PARALLEL
+#define HAS_PARALLEL_SUPPORT 1
+#else
+#define HAS_PARALLEL_SUPPORT 0
+#endif
+
+#if defined(NC_HAS_PARALLEL4) && NC_HAS_PARALLEL4
+#define HAS_PARALLEL4_SUPPORT 1
+#else
+#define HAS_PARALLEL4_SUPPORT 0
+#endif
+
+#if defined(NC_HAS_PNETCDF) && NC_HAS_PNETCDF
+#define HAS_PNETCDF_SUPPORT 1
+#else
+#define HAS_PNETCDF_SUPPORT 0
+#endif
+
+#if NC_VERSION_GE(4, 9, 0)
+#include <netcdf_filter.h>
+#define HAS_NCFILTER 1
+#else
+#define HAS_NCFILTER 0
+static inline int nc_inq_filter_avail(int ncid, unsigned filterid) { return -136; }
+#endif
+
+#if defined(NC_HAS_SZIP) && NC_HAS_SZIP
+#define HAS_SZIP_SUPPORT 1
+#else
+#define HAS_SZIP_SUPPORT 0
+static inline int nc_def_var_szip(int ncid, int varid, int options_mask, int pixels_per_bloc) { return NC_EINVAL; }
+# ifndef H5Z_FILTER_SZIP
+# define H5Z_FILTER_SZIP 4
+# endif
+#endif
+
+#if defined(NC_HAS_QUANTIZE) && NC_HAS_QUANTIZE
+#define HAS_QUANTIZATION_SUPPORT 1
+#else
+#define HAS_QUANTIZATION_SUPPORT 0
+# ifndef NC_HAS_QUANTIZE
+static inline int nc_def_var_quantize(int ncid, int varid, int quantize_mode, int nsd) { return NC_EINVAL; }
+static inline int nc_inq_var_quantize(int ncid, int varid, int *quantize_modep, int *nsdp) { return NC_EINVAL; }
+# define NC_NOQUANTIZE 0
+# define NC_QUANTIZE_BITGROOM 1
+# define NC_QUANTIZE_GRANULARBR 2
+# define NC_QUANTIZE_BITROUND 3
+# endif
+#endif
+
+#if defined(NC_HAS_ZSTANDARD) && NC_HAS_ZSTANDARD
+#define HAS_ZSTANDARD_SUPPORT 1
+#else
+# ifndef NC_HAS_ZSTANDARD
+static inline int nc_def_var_zstandard(int ncid, int varid, int level) { return NC_EINVAL; }
+static inline int nc_inq_var_zstandard(int ncid, int varid, int* hasfilterp, int *levelp) { return NC_EINVAL; }
+# define H5Z_FILTER_ZSTD 32015
+# endif
+#define HAS_ZSTANDARD_SUPPORT 0
+#endif
+
+#if defined(NC_HAS_BZIP2) && NC_HAS_BZIP2
+#define HAS_BZIP2_SUPPORT 1
+#else
+# ifndef NC_HAS_BZIP2
+static inline int nc_def_var_bzip2(int ncid, int varid, int level) { return NC_EINVAL; }
+static inline int nc_inq_var_bzip2(int ncid, int varid, int* hasfilterp, int *levelp) { return NC_EINVAL; }
+# define H5Z_FILTER_BZIP2 307
+# endif
+#define HAS_BZIP2_SUPPORT 0
+#endif
+
+#if defined(NC_HAS_BLOSC) && NC_HAS_BLOSC
+#define HAS_BLOSC_SUPPORT 1
+#else
+# ifndef NC_HAS_BLOSC
+static inline int nc_def_var_blosc(int ncid, int varid, unsigned subcompressor, unsigned level, unsigned blocksize, unsigned addshuffle) {
+  return NC_EINVAL;
+}
+static inline int nc_inq_var_blosc(int ncid, int varid, int* hasfilterp, unsigned* subcompressorp, unsigned* levelp, unsigned* blocksizep, unsigned* addshufflep) {
+  return NC_EINVAL;
+}
+# define H5Z_FILTER_BLOSC 32001
+# endif
+#define HAS_BLOSC_SUPPORT 0
+#endif

--- a/include/netcdf-compat.h
+++ b/include/netcdf-compat.h
@@ -96,6 +96,20 @@ static inline int nc_close_memio(int ncid, NC_memio* info) { return NC_EINVAL; }
 #define HAS_PARALLEL_SUPPORT 1
 #else
 #define HAS_PARALLEL_SUPPORT 0
+typedef int MPI_Comm;
+typedef int MPI_Info;
+static inline int nc_create_par(const char *path, int cmode, MPI_Comm comm, MPI_Info info, int *ncidp) { return NC_EINVAL; }
+static inline int nc_open_par(const char *path, int mode, MPI_Comm comm, MPI_Info info, int *ncidp) { return NC_EINVAL; }
+static inline int nc_var_par_access(int ncid, int varid, int par_access) { return NC_EINVAL; }
+# ifndef NC_INDEPENDENT
+#  define NC_INDEPENDENT 0
+#  define NC_COLLECTIVE 1
+# endif
+# ifndef NC_MPIIO
+#  define NC_MPIIO 0x2000
+#  define NC_MPIPOSIX NC_MPIIO
+#  define NC_PNETCDF (NC_MPIIO)
+# endif
 #endif
 
 #if defined(NC_HAS_PARALLEL4) && NC_HAS_PARALLEL4

--- a/include/no_parallel_support_imports.pxi.in
+++ b/include/no_parallel_support_imports.pxi.in
@@ -1,0 +1,8 @@
+# Stubs for when parallel support is not enabled
+
+ctypedef int Comm
+ctypedef int Info
+cdef Comm MPI_COMM_WORLD
+cdef Info MPI_INFO_NULL
+MPI_COMM_WORLD = 0
+MPI_INFO_NULL = 0

--- a/include/parallel_support_imports.pxi.in
+++ b/include/parallel_support_imports.pxi.in
@@ -1,0 +1,16 @@
+# Imports and typedefs required at compile time for enabling parallel support
+
+cimport mpi4py.MPI as MPI
+from mpi4py.libmpi cimport (
+    MPI_Comm,
+    MPI_Info,
+    MPI_Comm_dup,
+    MPI_Info_dup,
+    MPI_Comm_free,
+    MPI_Info_free,
+    MPI_INFO_NULL,
+    MPI_COMM_WORLD,
+)
+
+ctypedef MPI.Comm Comm
+ctypedef MPI.Info Info

--- a/setup.py
+++ b/setup.py
@@ -575,129 +575,20 @@ if 'sdist' not in sys.argv[1:] and 'clean' not in sys.argv[1:] and '--version' n
        (netcdf_lib_version > "4.4" and netcdf_lib_version < "4.5"):
         has_cdf5_format = True
 
-    # disable parallel support if mpi4py not available.
-    #try:
-    #    import mpi4py
-    #except ImportError:
-    #    f.write('disabling mpi parallel support because mpi4py not found\n')
-    #    has_parallel4_support = False
-    #    has_pnetcdf_support = False
+    with open(osp.join('include', 'constants.pyx'), 'w') as f:
+        if has_parallel4_support:
+            sys.stdout.write('netcdf lib has netcdf4 parallel functions\n')
+            f.write('DEF HAS_PARALLEL4_SUPPORT = 1\n')
+        else:
+            sys.stdout.write('netcdf lib does not have netcdf4 parallel functions\n')
+            f.write('DEF HAS_PARALLEL4_SUPPORT = 0\n')
 
-    f = open(osp.join('include', 'constants.pyx'), 'w')
-    if has_rename_grp:
-        sys.stdout.write('netcdf lib has group rename capability\n')
-        f.write('DEF HAS_RENAME_GRP = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have group rename capability\n')
-        f.write('DEF HAS_RENAME_GRP = 0\n')
-
-    if has_nc_inq_path:
-        sys.stdout.write('netcdf lib has nc_inq_path function\n')
-        f.write('DEF HAS_NC_INQ_PATH = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have nc_inq_path function\n')
-        f.write('DEF HAS_NC_INQ_PATH = 0\n')
-
-    if has_nc_inq_format_extended:
-        sys.stdout.write('netcdf lib has nc_inq_format_extended function\n')
-        f.write('DEF HAS_NC_INQ_FORMAT_EXTENDED = 1\n')
-    else:
-        sys.stdout.write(
-            'netcdf lib does not have nc_inq_format_extended function\n')
-        f.write('DEF HAS_NC_INQ_FORMAT_EXTENDED = 0\n')
-
-    if has_nc_open_mem:
-        sys.stdout.write('netcdf lib has nc_open_mem function\n')
-        f.write('DEF HAS_NC_OPEN_MEM = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have nc_open_mem function\n')
-        f.write('DEF HAS_NC_OPEN_MEM = 0\n')
-
-    if has_nc_create_mem:
-        sys.stdout.write('netcdf lib has nc_create_mem function\n')
-        f.write('DEF HAS_NC_CREATE_MEM = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have nc_create_mem function\n')
-        f.write('DEF HAS_NC_CREATE_MEM = 0\n')
-
-    if has_cdf5_format:
-        sys.stdout.write('netcdf lib has cdf-5 format capability\n')
-        f.write('DEF HAS_CDF5_FORMAT = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have cdf-5 format capability\n')
-        f.write('DEF HAS_CDF5_FORMAT = 0\n')
-
-    if has_parallel4_support:
-        sys.stdout.write('netcdf lib has netcdf4 parallel functions\n')
-        f.write('DEF HAS_PARALLEL4_SUPPORT = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have netcdf4 parallel functions\n')
-        f.write('DEF HAS_PARALLEL4_SUPPORT = 0\n')
-
-    if has_pnetcdf_support:
-        sys.stdout.write('netcdf lib has pnetcdf parallel functions\n')
-        f.write('DEF HAS_PNETCDF_SUPPORT = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have pnetcdf parallel functions\n')
-        f.write('DEF HAS_PNETCDF_SUPPORT = 0\n')
-
-    if has_quantize:
-        sys.stdout.write('netcdf lib has bit-grooming/quantization functions\n')
-        f.write('DEF HAS_QUANTIZATION_SUPPORT = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have bit-grooming/quantization functions\n')
-        f.write('DEF HAS_QUANTIZATION_SUPPORT = 0\n')
-
-    if has_zstandard:
-        sys.stdout.write('netcdf lib has zstandard compression functions\n')
-        f.write('DEF HAS_ZSTANDARD_SUPPORT = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have zstandard compression functions\n')
-        f.write('DEF HAS_ZSTANDARD_SUPPORT = 0\n')
-
-    if has_bzip2:
-        sys.stdout.write('netcdf lib has bzip2 compression functions\n')
-        f.write('DEF HAS_BZIP2_SUPPORT = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have bzip2 compression functions\n')
-        f.write('DEF HAS_BZIP2_SUPPORT = 0\n')
-
-    if has_blosc:
-        sys.stdout.write('netcdf lib has blosc compression functions\n')
-        f.write('DEF HAS_BLOSC_SUPPORT = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have blosc compression functions\n')
-        f.write('DEF HAS_BLOSC_SUPPORT = 0\n')
-
-    if has_szip_support:
-        sys.stdout.write('netcdf lib has szip compression functions\n')
-        f.write('DEF HAS_SZIP_SUPPORT = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have szip compression functions\n')
-        f.write('DEF HAS_SZIP_SUPPORT = 0\n')
-
-    if has_set_alignment:
-        sys.stdout.write('netcdf lib has nc_set_alignment function\n')
-        f.write('DEF HAS_SET_ALIGNMENT = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have nc_set_alignment function\n')
-        f.write('DEF HAS_SET_ALIGNMENT = 0\n')
-
-    if has_ncfilter:
-        sys.stdout.write('netcdf lib has nc_inq_filter_avail function\n')
-        f.write('DEF HAS_NCFILTER = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have nc_inq_filter_avail function\n')
-        f.write('DEF HAS_NCFILTER = 0\n')
-
-    if has_nc_rc_set:
-        sys.stdout.write('netcdf lib has nc_rc_set function\n')
-        f.write('DEF HAS_NCRCSET = 1\n')
-    else:
-        sys.stdout.write('netcdf lib does not have nc_rc_set function\n')
-        f.write('DEF HAS_NCRCSET = 0\n')
-
-    f.close()
+        if has_pnetcdf_support:
+            sys.stdout.write('netcdf lib has pnetcdf parallel functions\n')
+            f.write('DEF HAS_PNETCDF_SUPPORT = 1\n')
+        else:
+            sys.stdout.write('netcdf lib does not have pnetcdf parallel functions\n')
+            f.write('DEF HAS_PNETCDF_SUPPORT = 0\n')
 
     if has_parallel4_support or has_pnetcdf_support:
         import mpi4py

--- a/setup.py
+++ b/setup.py
@@ -487,7 +487,20 @@ if 'sdist' not in sys.argv[1:] and 'clean' not in sys.argv[1:] and '--version' n
         inc_dirs.append(mpi4py.get_include())
         # mpi_incdir should not be needed if using nc-config
         # (should be included in nc-config --cflags)
-        if mpi_incdir is not None: inc_dirs.append(mpi_incdir)
+        if mpi_incdir is not None:
+            inc_dirs.append(mpi_incdir)
+
+        # Name of file containing imports required for parallel support
+        parallel_support_imports = "parallel_support_imports.pxi.in"
+    else:
+        parallel_support_imports = "no_parallel_support_imports.pxi.in"
+
+    # Copy the specific version of the file containing parallel
+    # support imports
+    shutil.copyfile(
+        osp.join("include", parallel_support_imports),
+        osp.join("include", "parallel_support_imports.pxi")
+    )
 
     ext_modules = [Extension("netCDF4._netCDF4",
                              [netcdf4_src_pyx],

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -1244,7 +1244,7 @@ from numpy import ma
 from libc.string cimport memcpy, memset
 from libc.stdlib cimport malloc, free
 numpy.import_array()
-include "constants.pyx"
+include "parallel_support_imports.pxi"
 include "membuf.pyx"
 include "netCDF4.pxi"
 
@@ -1265,21 +1265,6 @@ __has_szip_support__ = HAS_SZIP_SUPPORT
 __has_set_alignment__ = HAS_SET_ALIGNMENT
 __has_ncfilter__ = HAS_NCFILTER
 
-
-IF HAS_PARALLEL_SUPPORT:
-    cimport mpi4py.MPI as MPI
-    from mpi4py.libmpi cimport MPI_Comm, MPI_Info, MPI_Comm_dup, MPI_Info_dup, \
-                               MPI_Comm_free, MPI_Info_free, MPI_INFO_NULL,\
-                               MPI_COMM_WORLD
-    ctypedef MPI.Comm Comm
-    ctypedef MPI.Info Info
-ELSE:
-    ctypedef int Comm
-    ctypedef int Info
-    cdef Comm MPI_COMM_WORLD
-    cdef Info MPI_INFO_NULL
-    MPI_COMM_WORLD = 0
-    MPI_INFO_NULL = 0
 
 # set path to SSL certificates (issue #1246)
 # available starting in version 4.9.1

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -1266,7 +1266,7 @@ __has_set_alignment__ = HAS_SET_ALIGNMENT
 __has_ncfilter__ = HAS_NCFILTER
 
 
-IF HAS_PARALLEL4_SUPPORT or HAS_PNETCDF_SUPPORT:
+IF HAS_PARALLEL_SUPPORT:
     cimport mpi4py.MPI as MPI
     from mpi4py.libmpi cimport MPI_Comm, MPI_Info, MPI_Comm_dup, MPI_Info_dup, \
                                MPI_Comm_free, MPI_Info_free, MPI_INFO_NULL,\


### PR DESCRIPTION
Fixes #1269 

The main trick I've used here is having a new C header `netcdf-compat.h` which does two things:

1. moves most of the API checking out of `setup.py`
2. defines stubs for the missing functions when a feature is missing

This allows us to eliminate most of the `DEF` statements and compile-time `IF` conditionals. We can also include everything unconditionally from this compatibility header in `netCDF4.pxi`. The use of the functions is still guarded at runtime, and I've flipped most of these guards to raise exceptions as soon as possible. The stubs all return `NC_EINVAL` so if for some reason a guard is missed or bypassed, they'll still raise an error and not silently fail.

I needed to use a different technique for the conditional `cimport` of mpi4py. For this, I moved the two branches into separate files, `[no_]parallel_support_imports.pxi.in`. The build system then chooses which one to copy to `parallel_support_imports.pxi` which we can then unconditionally include in the `.pyx` file.