### PR TITLE
add cibuildwheel GHA

### DIFF
--- a/.ci/build_deps.sh
+++ b/.ci/build_deps.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/bash
+
+set -ex
+
+
+download_and_build_netcdf() {
+  if [ ! -d "netcdf-c" ]; then
+      netcdf_url=https://github.com/Unidata/netcdf-c
+      netcdf_src=netcdf-c
+      netcdf_build=netcdf-build
+
+      git clone ${netcdf_url} -b v4.9.2 ${netcdf_src}
+
+      cmake ${netcdf_src} -B ${netcdf_build} \
+            -DENABLE_NETCDF4=on \
+            -DENABLE_HDF5=on \
+            -DENABLE_DAP=on \
+            -DENABLE_TESTS=off \
+            -DENABLE_PLUGIN_INSTALL=off \
+            -DBUILD_SHARED_LIBS=on \
+            -DCMAKE_BUILD_TYPE=Release
+
+      cmake --build ${netcdf_build} \
+            --target install
+fi
+}
+
+download_and_build_netcdf

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -102,7 +102,7 @@ jobs:
           environment-name: build
           init-shell: bash
           create-args: >-
-            python=${{ matrix.python-version }} hdf5 libnetcdf --channel conda-forge
+            python=${{ matrix.python-version }} libnetcdf=4.9.2 --channel conda-forge
 
       - name: Install cibuildwheel
         run: |
@@ -117,7 +117,9 @@ jobs:
             netCDF4_DIR="C:\\Users\\runneradmin\\micromamba\\envs\\build\\Library"
             PATH="C:\\Users\\runneradmin\\micromamba\\envs\\build\\Library\\bin;${PATH}"
           CIBW_BEFORE_BUILD: "python -m pip install delvewheel"
-          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
+            delvewheel show {wheel}
+            && delvewheel repair -w {dest_dir} {wheel}
           CIBW_TEST_COMMAND: >
             python -c "import netCDF4; print(f'netCDF4 v{netCDF4.__version__}')"
             && xcopy {project}\\test . /E/H

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -78,7 +78,6 @@ jobs:
           && dnf install -y hdf5-devel libcurl-devel
           && sh .ci/build_deps.sh
         CIBW_BEFORE_BUILD_MACOS: brew install hdf5 netcdf
-        CIBW_TEST_SKIP: "*_arm64"
         CIBW_TEST_REQUIRES: pytest cython packaging
         CIBW_TEST_COMMAND: >
           python -c "import netCDF4; print(f'netCDF4 v{netCDF4.__version__}')" &&
@@ -135,8 +134,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest cython packaging
           CIBW_TEST_COMMAND: >
             python -c "import netCDF4; print(f'netCDF4 v{netCDF4.__version__}')"
-            && xcopy {project}\\test . /E/H
-            && python run_all.py
+            && pytest -s -rxs -v {project}\\test
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -61,6 +63,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        submodules: 'true'
         
     - name: "Building ${{ matrix.os }} (${{ matrix.arch }}) wheels"
       uses: pypa/cibuildwheel@v2.18.1
@@ -97,6 +100,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: 'true'
 
       - uses: actions/setup-python@v4
         name: Install Python

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -52,8 +52,8 @@ jobs:
         include:
           - os: ubuntu-22.04
             arch: x86_64
-          - os: ubuntu-22.04
-            arch: aarch64
+          # - os: ubuntu-22.04
+          #   arch: aarch64
           - os: macos-14
             arch: arm64
           - os: macos-13

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -58,9 +58,9 @@ jobs:
           - os: macos-14
             arch: arm64
             CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=14.0
-          - os: macos-13
+          - os: macos-11
             arch: x86_64
-            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=13.0
+            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=11.0
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -144,7 +144,7 @@ jobs:
 
     - shell: bash
       run: |
-        ls -l ${{ github.workspace }}/dist
+        ls -lh ${{ github.workspace }}/dist
 
 
   publish-artifacts-pypi:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -16,7 +16,7 @@ jobs:
 
   build_sdist:
     name: Build source distribution
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -47,17 +47,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest"]
-        arch: ["x86_64", "arm64"]
-        exclude:
-        - os: ubuntu-latest
-          arch: arm64
+        include:
+          - os: ubuntu-22.04
+            arch: x86_64
+          - os: ubuntu-22.04
+            arch: aarch64
+          - os: macos-14
+            arch: arm64
+          - os: macos-13
+            arch: x86_64
 
     steps:
     - uses: actions/checkout@v4
-
+      with:
+        fetch-depth: 0
+        
     - name: "Building ${{ matrix.os }} (${{ matrix.arch }}) wheels"
-      uses: pypa/cibuildwheel@v2.15.0
+      uses: pypa/cibuildwheel@v2.18.1
       env:
         # Skips pypy and musllinux for now.
         CIBW_SKIP: "pp* cp36-* cp37-* *-musllinux*"
@@ -135,7 +141,7 @@ jobs:
   show-artifacts:
     needs: [build_bdist, build_sdist, build_wheels_windows]
     name: "Show artifacts"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/download-artifact@v3
       with:
@@ -150,7 +156,7 @@ jobs:
   publish-artifacts-pypi:
     needs: [build_bdist, build_sdist, build_wheels_windows]
     name: "Publish to PyPI"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # upload to PyPI for every tag starting with 'v'
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -38,9 +38,10 @@ jobs:
           pip install build
           &&  python -m build --sdist . --outdir dist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          path: dist/*.tar.gz
+          name: pypi-artifacts
+          path: ${{ github.workspace }}/dist/*.tar.gz
 
 
   build_bdist:
@@ -86,9 +87,9 @@ jobs:
           python -c "import netCDF4; print(f'netCDF4 v{netCDF4.__version__}')" &&
           cd {project}/test && python run_all.py
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: pypi-artifacts
+        name: pypi-artifacts-${{ matrix.os }}-${{ matrix.arch }}
         path: ${{ github.workspace }}/wheelhouse/*.whl
 
 
@@ -139,9 +140,9 @@ jobs:
             python -c "import netCDF4; print(f'netCDF4 v{netCDF4.__version__}')"
             && pytest -s -rxs -v {project}\\test
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
-          name: pypi-artifacts
+          name: pypi-artifacts-${{ matrix.os }}-${{ matrix.arch }}
           path: ${{ github.workspace }}/wheelhouse/*.whl
 
 

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -151,10 +151,11 @@ jobs:
     name: "Show artifacts"
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: pypi-artifacts
+        pattern: pypi-artifacts*
         path: ${{ github.workspace }}/dist
+        merge-multiple: true
 
     - shell: bash
       run: |

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -56,8 +56,10 @@ jobs:
           #   arch: aarch64
           - os: macos-14
             arch: arm64
+            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=14.0
           - os: macos-13
             arch: x86_64
+            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=13.0
 
     steps:
     - uses: actions/checkout@v4
@@ -77,6 +79,7 @@ jobs:
           dnf install -y epel-release
           && dnf install -y hdf5-devel libcurl-devel
           && sh .ci/build_deps.sh
+        CIBW_ENVIRONMENT: ${{ matrix.CIBW_ENVIRONMENT }}
         CIBW_BEFORE_BUILD_MACOS: brew install hdf5 netcdf
         CIBW_TEST_REQUIRES: pytest cython packaging
         CIBW_TEST_COMMAND: >

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -84,8 +84,8 @@ jobs:
         CIBW_BEFORE_BUILD_MACOS: brew install hdf5 netcdf
         CIBW_TEST_REQUIRES: pytest cython packaging
         CIBW_TEST_COMMAND: >
-          python -c "import netCDF4; print(f'netCDF4 v{netCDF4.__version__}')" &&
-          cd {project}/test && python run_all.py
+          python -c "import netCDF4; print(f'netCDF4 v{netCDF4.__version__}')"
+          && pytest -s -rxs -v {project}/test
 
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -70,7 +70,7 @@ jobs:
           && sh .ci/build_deps.sh
         CIBW_BEFORE_BUILD_MACOS: brew install hdf5 netcdf
         CIBW_TEST_SKIP: "*_arm64"
-        CIBW_TEST_REQUIRES: pytest cython
+        CIBW_TEST_REQUIRES: pytest cython packaging
         CIBW_TEST_COMMAND: >
           python -c "import netCDF4; print(f'netCDF4 v{netCDF4.__version__}')" &&
           cd {project}/test && python run_all.py
@@ -107,7 +107,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install --upgrade cibuildwheel
+          python -m pip install --upgrade cibuildwheel delvewheel
 
       - name: Build wheels for Windows (${{ matrix.arch }})
         run: cibuildwheel --output-dir wheelhouse
@@ -117,14 +117,13 @@ jobs:
             HDF5_DIR="C:\\Users\\runneradmin\\micromamba\\envs\\build\\Library"
             netCDF4_DIR="C:\\Users\\runneradmin\\micromamba\\envs\\build\\Library"
             PATH="C:\\Users\\runneradmin\\micromamba\\envs\\build\\Library\\bin;${PATH}"
-          CIBW_BEFORE_BUILD: "python -m pip install delvewheel"
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >
             delvewheel show {wheel}
             && delvewheel repair -w {dest_dir} {wheel}
+          CIBW_TEST_REQUIRES: pytest cython packaging
           CIBW_TEST_COMMAND: >
             python -c "import netCDF4; print(f'netCDF4 v{netCDF4.__version__}')"
             && xcopy {project}\\test . /E/H
-            && python -m pip install --upgrade numpy cython packaging
             && python run_all.py
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,0 +1,164 @@
+name: Wheels
+
+on:
+  pull_request:
+  push:
+    tags:
+      - "v*"
+  release:
+    types:
+      - published
+
+permissions:
+  contents: read
+
+jobs:
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: 3.x
+
+      - name: Install APT packages
+        if: contains(${{ matrix.os }}, 'ubuntu')
+        run: |
+          sudo apt update
+          sudo apt install libhdf5-dev libnetcdf-dev
+
+      - name: Build sdist
+        run: >
+          pip install build
+          &&  python -m build --sdist . --outdir dist
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*.tar.gz
+
+
+  build_bdist:
+    name: "Build ${{ matrix.os }} (${{ matrix.arch }}) wheels"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest"]
+        arch: ["x86_64", "arm64"]
+        exclude:
+        - os: ubuntu-latest
+          arch: arm64
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: "Building ${{ matrix.os }} (${{ matrix.arch }}) wheels"
+      uses: pypa/cibuildwheel@v2.15.0
+      env:
+        # Skips pypy and musllinux for now.
+        CIBW_SKIP: "pp* cp36-* cp37-* *-musllinux*"
+        CIBW_ARCHS: ${{ matrix.arch }}
+        CIBW_BUILD_FRONTEND: build
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+        CIBW_BEFORE_BUILD_LINUX: yum install -y hdf5-devel netcdf-devel
+        CIBW_BEFORE_BUILD_MACOS: brew install hdf5 netcdf
+        CIBW_TEST_SKIP: "*_arm64"
+        CIBW_TEST_REQUIRES: pytest cython
+        CIBW_TEST_COMMAND: >
+          python -c "import netCDF4; print(f'netCDF4 v{netCDF4.__version__}')" &&
+          cd {project}/test && python run_all.py
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: pypi-artifacts
+        path: ${{ github.workspace }}/wheelhouse/*.whl
+
+
+  build_wheels_windows:
+    name: Build wheels for ${{matrix.arch}} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest]
+        arch: [win_amd64]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: 3.x
+
+      - name: Setup Micromamba Python ${{ matrix.python-version }}
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: build
+          init-shell: bash
+          create-args: >-
+            python=${{ matrix.python-version }} hdf5 libnetcdf --channel conda-forge
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install --upgrade cibuildwheel
+
+      - name: Build wheels for Windows (${{ matrix.arch }})
+        run: cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: "cp39-${{ matrix.arch }} cp310-${{ matrix.arch }} cp311-${{ matrix.arch }} cp312-${{ matrix.arch }}"
+          CIBW_ENVIRONMENT_WINDOWS: >
+            HDF5_DIR="C:\\Users\\runneradmin\\micromamba\\envs\\build\\Library"
+            netCDF4_DIR="C:\\Users\\runneradmin\\micromamba\\envs\\build\\Library"
+            PATH="C:\\Users\\runneradmin\\micromamba\\envs\\build\\Library\\bin;${PATH}"
+          CIBW_BEFORE_BUILD: "python -m pip install delvewheel"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
+          CIBW_TEST_COMMAND: >
+            python -c "import netCDF4; print(f'netCDF4 v{netCDF4.__version__}')"
+            && xcopy {project}\\test . /E/H
+            && python -m pip install --upgrade numpy cython packaging
+            && python run_all.py
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pypi-artifacts
+          path: ${{ github.workspace }}/wheelhouse/*.whl
+
+
+  show-artifacts:
+    needs: [build_bdist, build_sdist, build_wheels_windows]
+    name: "Show artifacts"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: pypi-artifacts
+        path: ${{ github.workspace }}/dist
+
+    - shell: bash
+      run: |
+        ls -l ${{ github.workspace }}/dist
+
+
+  publish-artifacts-pypi:
+    needs: [build_bdist, build_sdist, build_wheels_windows]
+    name: "Publish to PyPI"
+    runs-on: ubuntu-latest
+    # upload to PyPI for every tag starting with 'v'
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
+    steps:
+    - uses: actions/download-artifact@v3
+      with:
+        name: pypi-artifacts
+        path: ${{ github.workspace }}/dist
+
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_PASSWORD }}
+        print_hash: true

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -55,8 +55,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
 
     - name: "Building ${{ matrix.os }} (${{ matrix.arch }}) wheels"
       uses: pypa/cibuildwheel@v2.15.0
@@ -65,8 +63,11 @@ jobs:
         CIBW_SKIP: "pp* cp36-* cp37-* *-musllinux*"
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD_FRONTEND: build
-        CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-        CIBW_BEFORE_BUILD_LINUX: yum install -y hdf5-devel netcdf-devel
+        CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+        CIBW_BEFORE_BUILD_LINUX: >
+          dnf install -y epel-release
+          && dnf install -y hdf5-devel libcurl-devel
+          && sh .ci/build_deps.sh
         CIBW_BEFORE_BUILD_MACOS: brew install hdf5 netcdf
         CIBW_TEST_SKIP: "*_arm64"
         CIBW_TEST_REQUIRES: pytest cython

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -67,12 +67,26 @@ jobs:
       with:
         fetch-depth: 0
         submodules: 'true'
-        
+    
+    - name: Build oldest and newest Python
+      shell: bash
+      # On PRs we run only oldest and newest Python versions to reduce CI load.
+      # Skips pypy and musllinux everywhere.
+      # We are buiding 38 and 312 for now.
+      # These needs to rotate every new Python release.
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          CIBW_SKIP="pp* cp36-* cp37-* *-musllinux* cp39-* cp310-* cp311-*"
+        else
+          CIBW_SKIP="pp* cp36-* cp37-* *-musllinux*"
+        fi
+        echo "CIBW_SKIP=$CIBW_SKIP" >> $GITHUB_ENV
+        echo "Setting CIBW_SKIP=$CIBW_SKIP"
+
     - name: "Building ${{ matrix.os }} (${{ matrix.arch }}) wheels"
       uses: pypa/cibuildwheel@v2.18.1
       env:
-        # Skips pypy and musllinux for now.
-        CIBW_SKIP: "pp* cp36-* cp37-* *-musllinux*"
+        CIBW_SKIP: ${{ env.CIBW_SKIP }}
         CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_BUILD_FRONTEND: build
         CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ requires = [
     "oldest-supported-numpy ; python_version < '3.9'",
     "numpy>=2.0.0rc1 ; python_version >= '3.9'",
     "setuptools>=61",
+    "packaging",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = [
     "oldest-supported-numpy ; python_version < '3.9'",
     "numpy>=2.0.0rc1 ; python_version >= '3.9'",
     "setuptools>=61",
-    "packaging",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -47,7 +46,6 @@ tests = [
   "packaging",
   "pytest",
 ]
-
 
 [project.readme]
 text = """\

--- a/test/run_all.py
+++ b/test/run_all.py
@@ -16,7 +16,7 @@ for f in test_files:
     testsuite.addTests(unittest.TestLoader().loadTestsFromModule(m))
 
 # Run the test suite.
-def test(verbosity=1):
+def test(verbosity=2):
     runner = unittest.TextTestRunner(verbosity=verbosity)
     runner.run(testsuite)
 

--- a/test/run_all.py
+++ b/test/run_all.py
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     sys.stdout.write('netcdf lib version:     %s\n' % __netcdf4libversion__)
     sys.stdout.write('numpy version           %s\n' % numpy.__version__)
     sys.stdout.write('cython version          %s\n' % cython.__version__)
-    runner = unittest.TextTestRunner(verbosity=2)
+    runner = unittest.TextTestRunner(verbosity=1)
     result = runner.run(testsuite)
     if not result.wasSuccessful():
         sys.exit(1)

--- a/test/run_all.py
+++ b/test/run_all.py
@@ -15,10 +15,6 @@ for f in test_files:
     m = __import__(os.path.splitext(f)[0])
     testsuite.addTests(unittest.TestLoader().loadTestsFromModule(m))
 
-# Run the test suite.
-def test(verbosity=2):
-    runner = unittest.TextTestRunner(verbosity=verbosity)
-    runner.run(testsuite)
 
 if __name__ == '__main__':
     import numpy, cython
@@ -28,7 +24,7 @@ if __name__ == '__main__':
     sys.stdout.write('netcdf lib version:     %s\n' % __netcdf4libversion__)
     sys.stdout.write('numpy version           %s\n' % numpy.__version__)
     sys.stdout.write('cython version          %s\n' % cython.__version__)
-    runner = unittest.TextTestRunner(verbosity=1)
+    runner = unittest.TextTestRunner(verbosity=2)
     result = runner.run(testsuite)
     if not result.wasSuccessful():
         sys.exit(1)


### PR DESCRIPTION
This is just a proof of concept to see if we can build wheels here. We probably want to build out own hdf5 and netcdf-c b/c the ones from CentOS are quite old probably the source of the failures we are seeing in the tests here. See https://github.com/MacPython/netcdf4-python-wheels/blob/master/config.sh#L13-L26 for the versions used in the muiltbuild.

xref.: #1204