### PR TITLE
mpi-compat: support MPI_Message on MS-MPI

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,7 @@
  * add support for complex numbers via `auto_complex` keyword to `Dataset` (PR #1295)
  * fix for deprecated Cython `DEF` and `IF` statements using compatibility header
    with shims for unavailable functionality (PR #1277)
+ * add support for MS-MPI `MPI_Message` detection (PR #1305)
 
  version 1.6.5 (tag v1.6.5rel)
 ===============================

--- a/include/mpi-compat.h
+++ b/include/mpi-compat.h
@@ -10,6 +10,10 @@
 
 #include <mpi.h>
 
+#ifdef MSMPI_VER
+#define PyMPI_HAVE_MPI_Message 1
+#endif
+
 #if (MPI_VERSION < 3) && !defined(PyMPI_HAVE_MPI_Message)
 typedef void *PyMPI_MPI_Message;
 #define MPI_Message PyMPI_MPI_Message


### PR DESCRIPTION
MS-MPI does not define an accurate `MPI_VERSION`, so `MPI_Message` is mis-detected.

See: https://github.com/mpi4py/mpi4py/issues/19