### PR TITLE
BLD: build with numpy 2.0.0rc1 (or newer) on Python >= 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [build-system]
 requires = [
     "Cython>=0.29",
-    "oldest-supported-numpy",
+    "oldest-supported-numpy ; python_version < '3.9'",
+    "numpy>=2.0.0rc1 ; python_version >= '3.9'",
     "setuptools>=61",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
For more context:
- `oldest-supported-numpy` is superseded by NumPy itself [since version 1.25.0](https://numpy.org/doc/stable/release/1.25.0-notes.html#compiling-against-the-numpy-c-api-is-now-backwards-compatible-by-default)
- NumPy 2 just reached ABI stability with the release of version 2.0.0rc1 a couple days ago, and forward compatibility with it requires building against this newest version instead of oldest ones.

It is [recommended by NumPy developers](https://github.com/numpy/numpy/issues/24300#issue-1828940995) to plan releases of packages with Python extensions a some point between 2.0.0rc1 and 2.0.0 (final).

Apologies if I missed something obvious: I didn't have time to test locally so I'm relying on CI to reveal any potential incompatibilities. I'll have more time later today to properly dig into it if needed.