### PR TITLE
Fix bug in set_collective added in #1277

### DIFF
--- a/.github/workflows/miniconda.yml
+++ b/.github/workflows/miniconda.yml
@@ -83,8 +83,8 @@ jobs:
         export PATH="${CONDA_PREFIX}/bin:${CONDA_PREFIX}/Library/bin:$PATH" 
         which mpirun
         mpirun --version
-        #mpirun -np 4 --oversubscribe python mpi_example.py # for openmpi
-        mpirun -np 4 python mpi_example.py
+        mpirun -np 4 --oversubscribe python mpi_example.py # for openmpi
+        #mpirun -np 4 python mpi_example.py
         if [ $? -ne 0 ] ; then
           echo "hdf5 mpi test failed!"
           exit 1

--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,8 @@
  * add support for MS-MPI `MPI_Message` detection (PR #1305)
  * fix for issue #1306 - surprising result when indexing vlen str with non-contiguous
    indices.
+ * Fix bug in set_collective introduced in PR #1277 (collective mode was
+   always set).
 
 
 

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -6060,7 +6060,7 @@ NC_CHAR).
         mode = NC_COLLECTIVE if value else NC_INDEPENDENT
         with nogil:
             ierr = nc_var_par_access(self._grpid, self._varid,
-                   NC_COLLECTIVE)
+                   mode)
         _ensure_nc_success(ierr)
 
 


### PR DESCRIPTION
Fix bug added in commit f64ee26773502c7568b1ceefe5967f83230f207c that cause `set_collective` to always set collective mode, regardless of the `value` input argument.