### PR TITLE
Fix incompatbile pointer argument to nc_put_att_string()

### DIFF
--- a/include/netCDF4.pxi
+++ b/include/netCDF4.pxi
@@ -263,7 +263,7 @@ cdef extern from "netcdf.h":
                size_t len, void *op) nogil
     int nc_get_att(int ncid, int varid, char *name, void *ip) nogil
     int nc_get_att_string(int ncid, int varid, char *name, char **ip) nogil
-    int nc_put_att_string(int ncid, int varid, char *name, size_t len, char **op) nogil
+    int nc_put_att_string(int ncid, int varid, char *name, size_t len, const char **op) nogil
     int nc_def_opaque(int ncid, size_t size, char *name, nc_type *xtypep) nogil
     int nc_inq_opaque(int ncid, nc_type xtype, char *name, size_t *sizep) nogil
     int nc_put_att_opaque(int ncid, int varid, char *name,

--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -1796,7 +1796,7 @@ be raised in the next release."""
                     string_ptrs[j] = strings[j]
                 issue485_workaround(grpid, varid, attname)
                 with nogil:
-                    ierr = nc_put_att_string(grpid, varid, attname, N, string_ptrs)
+                    ierr = nc_put_att_string(grpid, varid, attname, N, <const char**>string_ptrs)
             finally:
                 PyMem_Free(string_ptrs)
         else:
@@ -1825,7 +1825,7 @@ be raised in the next release."""
                 except UnicodeError:
                     issue485_workaround(grpid, varid, attname)
                     with nogil:
-                        ierr = nc_put_att_string(grpid, varid, attname, 1, &datstring)
+                        ierr = nc_put_att_string(grpid, varid, attname, 1, <const char**>&datstring)
             else:
                 with nogil:
                     ierr = nc_put_att_text(grpid, varid, attname, lenarr, datstring)


### PR DESCRIPTION
This is causing compilation to fail on Fedora 40 due to stricter compilation flags:
```
gcc -fno-strict-overflow -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -fexceptions -fcf-protection -fexceptions -fcf-protection -fexceptions -fcf-protection -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -march=x86-64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -mtls-dialect=gnu2 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fPIC -DNPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION -I/usr/include -I/usr/include/hdf -I/usr/lib64/python3.12/site-packages/numpy/core/include -Iinclude -I/usr/include/python3.12 -c src/netCDF4/_netCDF4.c -o build/temp.linux-x86_64-cpython-312/src/netCDF4/_netCDF4.o
src/netCDF4/_netCDF4.c: In function ‘__pyx_pf_7netCDF4_8_netCDF4_7_MemBuf_4__dealloc__’:
src/netCDF4/_netCDF4.c:12717:20: warning: passing argument 1 of ‘free’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
12717 |   free(__pyx_v_self->memory);
      |        ~~~~~~~~~~~~^~~~~~~~
In file included from /usr/include/python3.12/Python.h:23,
                 from src/netCDF4/_netCDF4.c:59:
/usr/include/stdlib.h:687:25: note: expected ‘void *’ but argument is of type ‘const void *’
  687 | extern void free (void *__ptr) __THROW;
      |                   ~~~~~~^~~~~
src/netCDF4/_netCDF4.c: In function ‘__pyx_f_7netCDF4_8_netCDF4__set_att’:
src/netCDF4/_netCDF4.c:17890:106: error: passing argument 5 of ‘nc_put_att_string’ from incompatible pointer type [-Wincompatible-pointer-types]
17890 |               __pyx_v_ierr = nc_put_att_string(__pyx_v_grpid, __pyx_v_varid, __pyx_v_attname, __pyx_v_N, __pyx_v_string_ptrs);
      |                                                                                                          ^~~~~~~~~~~~~~~~~~~
      |                                                                                                          |
      |                                                                                                          char **
In file included from src/netCDF4/_netCDF4.c:1248:
/usr/include/netcdf.h:1113:44: note: expected ‘const char **’ but argument is of type ‘char **’
 1113 |                   size_t len, const char **op);
      |                               ~~~~~~~~~~~~~^~
src/netCDF4/_netCDF4.c:18417:103: error: passing argument 5 of ‘nc_put_att_string’ from incompatible pointer type [-Wincompatible-pointer-types]
18417 |                   __pyx_v_ierr = nc_put_att_string(__pyx_v_grpid, __pyx_v_varid, __pyx_v_attname, 1, (&__pyx_v_datstring));
      |                                                                                                      ~^~~~~~~~~~~~~~~~~~~
      |                                                                                                       |
      |                                                                                                       char **
/usr/include/netcdf.h:1113:44: note: expected ‘const char **’ but argument is of type ‘char **’
 1113 |                   size_t len, const char **op);
      |                               ~~~~~~~~~~~~~^~
src/netCDF4/_netCDF4.c: In function ‘__pyx_f_7netCDF4_8_netCDF4__read_compound’:
src/netCDF4/_netCDF4.c:84710:35: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
84710 |   for (__pyx_v_nf = 0; __pyx_v_nf < __pyx_t_7; __pyx_v_nf++) {
      |                                   ^
src/netCDF4/_netCDF4.c: In function ‘__pyx_f_7netCDF4_8_netCDF4__read_enum’:
src/netCDF4/_netCDF4.c:88917:39: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
88917 |   for (__pyx_v_nmem = 0; __pyx_v_nmem < __pyx_t_11; __pyx_v_nmem++) {
      |                                       ^
error: command '/usr/bin/gcc' failed with exit code 1
```