### PR TITLE
remove submodules from checkout actions

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: 'true'
 
       - uses: actions/setup-python@v4
         name: Install Python
@@ -69,7 +68,6 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        submodules: 'true'
 
     # For aarch64 support
     # https://cibuildwheel.pypa.io/en/stable/faq/#emulation
@@ -130,7 +128,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: 'true'
 
       - uses: actions/setup-python@v4
         name: Install Python

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          submodules: 'true'
 
       - uses: actions/setup-python@v4
         name: Install Python


### PR DESCRIPTION
@jswhit I'm not a big fan of submodules b/c they add an extra layer of complexity, specially with code tracking/versioning. This change will ship the latest submodule code with the sdist. We are already using the same when building the wheels. Which, BTW, stomped me for a while until I realized they were missing.

Closes #1331 and #1329.