### PR TITLE
chore: include missing netcdf headers in manifest / sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,6 +17,9 @@ include src/netCDF4/plugins/empty.txt
 include include/netCDF4.pxi
 include include/mpi-compat.h
 include include/membuf.pyx
+include include/netcdf-compat.h
+include include/no_parallel_support_imports.pxi.in
+include include/parallel_support_imports.pxi.in
 include *.md
 include *.py
 include *.release


### PR DESCRIPTION
Include missing `netcdf` headers during packaging (i.e. in an `sdist`). These are opened in `setup.py` in certain build configurations if building from a source distribution.

related #1329