### PR TITLE
Fix random "only endian='native' allowed for NETCDF3 files" error

### DIFF
--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -2062,10 +2062,11 @@ cdef _get_vars(group, bint auto_complex=False):
             endianness = None
             with nogil:
                 ierr = nc_inq_var_endian(_grpid, varid, &iendian)
-            if ierr == NC_NOERR and iendian == NC_ENDIAN_LITTLE:
-                endianness = '<'
-            elif iendian == NC_ENDIAN_BIG:
-                endianness = '>'
+            if ierr == NC_NOERR:
+                if iendian == NC_ENDIAN_LITTLE:
+                    endianness = '<'
+                elif iendian == NC_ENDIAN_BIG:
+                    endianness = '>'
             # check to see if it is a supported user-defined type.
             try:
                 datatype = _nctonptype[xtype]


### PR DESCRIPTION
When I open NetCDF3 files using `netCDF4.Dataset(filename, "r")`, I sometimes get the following errors and sometimes not.

```
  File "src/netCDF4/_netCDF4.pyx", line 2489, in netCDF4._netCDF4.Dataset.__init__
  File "src/netCDF4/_netCDF4.pyx", line 2092, in netCDF4._netCDF4._get_vars
  File "src/netCDF4/_netCDF4.pyx", line 4062, in netCDF4._netCDF4.Variable.__init__
RuntimeError: only endian='native' allowed for NETCDF3 files, got 'big' (variable 'FOO', group '/')
```

It seems that `nc_inq_var_endian()` returns `NC_ENOTNC4` and `iendian` is left uninitialized in that case.