### PR TITLE
Add py313 to the Windows wheel builds

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Build wheels for Windows (${{ matrix.arch }})
         run: cibuildwheel --output-dir wheelhouse
         env:
-          CIBW_BUILD: "cp39-${{ matrix.arch }} cp310-${{ matrix.arch }} cp311-${{ matrix.arch }} cp312-${{ matrix.arch }}"
+          CIBW_BUILD: "cp39-${{ matrix.arch }} cp310-${{ matrix.arch }} cp311-${{ matrix.arch }} cp312-${{ matrix.arch }} cp313-${{ matrix.arch }}"
           CIBW_ENVIRONMENT_WINDOWS: >
             HDF5_DIR="C:\\Users\\runneradmin\\micromamba\\envs\\build\\Library"
             netCDF4_DIR="C:\\Users\\runneradmin\\micromamba\\envs\\build\\Library"


### PR DESCRIPTION
@jswhit sorry but I forget to update this part here. I would do a manual upload to avoid a post release, we don't need to re-upload everything just for a single missing wheel.