### PR TITLE
DOC: Try to keep &lt;code&gt; tags from appearing in rendered docs

### DIFF
--- a/src/netCDF4/_netCDF4.pyx
+++ b/src/netCDF4/_netCDF4.pyx
@@ -2331,8 +2331,8 @@ strings.
         exception will be raised if a file with the same name already exists.
         mode=`x` is identical to mode=`w` with clobber=False.
 
-        **`format`**: underlying file format (one of `'NETCDF4',
-        'NETCDF4_CLASSIC', 'NETCDF3_CLASSIC'`, `'NETCDF3_64BIT_OFFSET'` or
+        **`format`**: underlying file format (one of `'NETCDF4'`,
+        `'NETCDF4_CLASSIC'`, `'NETCDF3_CLASSIC'`, `'NETCDF3_64BIT_OFFSET'` or
         `'NETCDF3_64BIT_DATA'`.
         Only relevant if `mode = 'w'` (if `mode = 'r','a'` or `'r+'` the file format
         is automatically detected). Default `'NETCDF4'`, which means the data is


### PR DESCRIPTION
https://unidata.github.io/netcdf4-python/#netCDF4.Dataset 
Scroll down to "`format`: underlying file format", which shows
> 'NETCDF3_CLASSIC'&lt;code&gt;, &lt;/code&gt;'NETCDF3_64BIT_OFFSET'

This is also visible in the processed HTML here:
https://github.com/Unidata/netcdf4-python/blob/f7b00f8257978db86a98cf27764c4daa5503c6dd/docs/index.html#L1556

I have no idea why it decided to (1) nest the code tags, instead of ending the already-open one and opening a second, nor (2) entity-escape the tags it added so they would show up in the rendered HTML (as opposed to giving directions to the browser).

Not sure if this should be ReST's double-backticks for code or Markdown's single backticks, though the default role Sphinx assigns to single backticks should work (though I have no idea if pdoc has an equivalent concept).  In any case, it works everywhere else, so hopefully it works here too.

EDIT: [pdoc seems to have an equivalent to Sphinx's `` `identifier` ``-> ``:any:`identifier` ``magic](https://pdoc3.github.io/pdoc/doc/pdoc/#linking-to-other-identifiers), at least in that placing a documented identifier in single ticks will link to the documentation for that identifier.  It doesn't say whether double-backticks disables that, though.