### PR TITLE
Fix test_tocdl to pass on Windows.

### DIFF
--- a/test/test_cdl.py
+++ b/test/test_cdl.py
@@ -55,7 +55,7 @@ class Test_CDL(unittest.TestCase):
 
     def test_tocdl(self):
         # treated as unsigned integers.
-        with netCDF4.Dataset(ubyte_filename) as f:
+        with netCDF4.Dataset(os.path.basename(ubyte_filename)) as f:
             assert f.tocdl() == test_ncdump
             assert f.tocdl(data=True) == test_ncdump2
 


### PR DESCRIPTION
Fixes test_tocdl on Windows. 

The expected output is:

```
netcdf ubyte {
dimensions:
        d = 2 ;
variables:
        byte ub(d) ;
                ub:_Unsigned = "true" ;
        byte sb(d) ;
        byte sb2(d) ;
                sb2:_Unsigned = "false" ;

// global attributes:
                :_Format = "classic" ;
}
```

But when the full path is provided, the output is something like:

```
netcdf C\:\\Users\\dev-admin\\Desktop\\netcdf\\netcdf4_1737132718267\\test_tmp\\test\\ubyte {
dimensions:
        d = 2 ;
variables:
        byte ub(d) ;
                ub:_Unsigned = "true" ;
        byte sb(d) ;
        byte sb2(d) ;
                sb2:_Unsigned = "false" ;

// global attributes:
                :_Format = "classic" ;
}
```

Using the `basename` fixes this. 