### PR TITLE
Fix incorrect const qualifier in membuf.pyx

### DIFF
--- a/include/membuf.pyx
+++ b/include/membuf.pyx
@@ -14,7 +14,7 @@ cdef memview_fromptr(void *memory, size_t size):
 
 # private extension type that implements buffer protocol.
 cdef class _MemBuf:
-    cdef const void *memory
+    cdef void *memory
     cdef size_t size
     def __getbuffer__(self, Py_buffer *buf, int flags):
         PyBuffer_FillInfo(buf, self, <void *>self.memory, self.size, 1, flags)


### PR DESCRIPTION
Without this change, I see errors when building netCDF4-python, originating at the line `free(self.memory)` in  `__dealloc__()`:

    .../_cython/_netCDF4.cc:12922:3: error: no matching function for call to 'free'
     12922 |   free(__pyx_v_self->memory);
           |   ^~~~
    .../include/stdlib.h:563:13: note: candidate function not viable: 1st argument ('const void *') would lose const qualifier
      563 | extern void free (void *__ptr) __THROW;
          |             ^     ~~~~~~~~~~~

Apparently it is not valid to call `free()` on a `const` variable.