### PR TITLE
Skip cp314t for now and build cp314 on PRs

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -60,9 +60,9 @@ jobs:
           - os: macos-14
             arch: arm64
             CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=14.0
-          - os: macos-12
+          - os: macos-13
             arch: x86_64
-            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=12.0
+            CIBW_ENVIRONMENT: MACOSX_DEPLOYMENT_TARGET=13.0
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
@jswhit I also had to update many of the dependencies in https://github.com/ocefpaf/netcdf-manylinux and the manylinux version to get this working with Python 3.14. The build is working now, but 2  tests are when excuted with the built wheel. Do you mind taking a look? I'm not sure I know where to start fixing them. Maybe downgrading hdf5?

Closes #1413 