### PR TITLE
bump netcdf-c to 4.10.1

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -125,7 +125,7 @@ jobs:
           environment-name: build
           init-shell: bash
           create-args: >-
-            python=${{ matrix.python-version }} libnetcdf=4.9.3 --channel conda-forge
+            python=${{ matrix.python-version }} libnetcdf=4.10.1 --channel conda-forge
 
       - name: Build wheels for Windows/Mac 
         uses: pypa/cibuildwheel@v4.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,8 +122,8 @@ test-command = [
     '''python -c "import netCDF4; print(f'netCDF4 v{netCDF4.__version__}')"''',
     "pytest -s -rxs -v test",
 ]
-manylinux-x86_64-image = "ghcr.io/Unidata/manylinux_2_28_x86_64-netcdf"
-manylinux-aarch64-image = "ghcr.io/Unidata/manylinux_2_28_aarch64-netcdf"
+manylinux-x86_64-image = "ghcr.io/unidata/manylinux_2_28_x86_64-netcdf"
+manylinux-aarch64-image = "ghcr.io/unidata/manylinux_2_28_aarch64-netcdf"
 environment = {NETCDF4_LIMITED_API="1"}
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,8 +122,8 @@ test-command = [
     '''python -c "import netCDF4; print(f'netCDF4 v{netCDF4.__version__}')"''',
     "pytest -s -rxs -v test",
 ]
-manylinux-x86_64-image = "ghcr.io/ocefpaf/manylinux_2_28_x86_64-netcdf"
-manylinux-aarch64-image = "ghcr.io/ocefpaf/manylinux_2_28_aarch64-netcdf"
+manylinux-x86_64-image = "ghcr.io/Unidata/manylinux_2_28_x86_64-netcdf"
+manylinux-aarch64-image = "ghcr.io/Unidata/manylinux_2_28_aarch64-netcdf"
 environment = {NETCDF4_LIMITED_API="1"}
 
 [tool.cibuildwheel.macos]


### PR DESCRIPTION
@jswhit I created a [new repository](https://github.com/ocefpaf/netcdf4-python-manylinux), disconnected from the h5py one, for the netcdf-c manylinux docker image. Ideally this repository should be moved/copiedcloned//copied to the Unidata organization.

I also updated netcdf-c to 4.10.1 and hdf5 to 2.2.0 in the image. This PR bumps libnetcdf from conda-forge 4.10.1 (built against hdf5 2.2.0) as well.