### PR TITLE
fix Linux/macOS HDF5_PLUGIN_PATH in miniconda.yml (compression plugin tests silently skip on ubuntu/macos)

### DIFF
--- a/.github/workflows/miniconda.yml
+++ b/.github/workflows/miniconda.yml
@@ -55,7 +55,7 @@ jobs:
         if [ "$RUNNER_OS" == "Windows" ]; then
            export HDF5_PLUGIN_PATH="${CONDA_PREFIX}\\Library\\hdf5\\lib\\plugin"
         else
-           export HDF5_PLUGIN_PATH="${CONDA_PREFIX}/hdf5/lib/plugin/"
+           export HDF5_PLUGIN_PATH="${CONDA_PREFIX}/lib/hdf5/plugin/"
         fi
         pytest -s -rxs -v test
 


### PR DESCRIPTION
On Linux and macOS, the Tests step in `miniconda.yml` exports `HDF5_PLUGIN_PATH="${CONDA_PREFIX}/hdf5/lib/plugin/"` — a directory that doesn't exist in the micromamba env. conda-forge installs the netcdf-c filter plugins at `${CONDA_PREFIX}/lib/hdf5/plugin` (the `H5_DEFAULT_PLUGINDIR` baked into conda-forge hdf5 — [hdf5-feedstock build.sh L88](https://github.com/conda-forge/hdf5-feedstock/blob/8ceb83008fd3/recipe/build.sh#L88) — which the [libnetcdf feedstock uses as its plugin install dir](https://github.com/conda-forge/libnetcdf-feedstock/blob/427106b9e03f/recipe/build.sh#L49-L52)). With the variable pointing at the empty path, `has_zstd_filter()`/`has_bzip2_filter()`/`has_blosc_filter()` return False and `test_compression_{zstd,bzip2,blosc}.py` skip with "filter not available" on every ubuntu/macos job of Build and Test, while the Windows jobs — whose `${CONDA_PREFIX}\Library\hdf5\lib\plugin` path is correct — run them. Latest master run: [ubuntu 3.12](https://github.com/Unidata/netcdf4-python/actions/runs/32658631694/job/97241277452) `109 passed, 6 skipped` vs [windows 3.12](https://github.com/Unidata/netcdf4-python/actions/runs/32658631694/job/97241277545) `111 passed, 3 skipped, 1 xpassed`.

Inside the workflow's env:

```
$ ls "${CONDA_PREFIX}/hdf5/lib/plugin/"     # what the workflow exports
ls: cannot access '.../hdf5/lib/plugin/': No such file or directory
$ ls "${CONDA_PREFIX}/lib/hdf5/plugin"      # where the plugins are
lib__nch5blosc.so  lib__nch5bzip2.so  lib__nch5zstd.so  ...
```

Verified on my fork at current master (ad9d7d8), runs [1](https://github.com/glaziermag/netcdf4-python/actions/runs/33259582309) and [2](https://github.com/glaziermag/netcdf4-python/actions/runs/33259884687): the unchanged path reproduces the three skips on ubuntu and macos (`109 passed, 6 skipped`), and with this one-line change they run and pass, matching Windows (`111 passed, 3 skipped, 1 xpassed`). The Windows half of this export was tuned against CI directory listings in #1450 ([8f83e40](https://github.com/Unidata/netcdf4-python/commit/8f83e4018d) "set HDF5_PLUGIN_PATH for tests"), but the Linux/macOS half kept the original guess from [2d6c8d4](https://github.com/Unidata/netcdf4-python/commit/2d6c8d41ef), and the skips keep the jobs green.

Disclosure: found while auditing CI logs with an AI assistant (Claude); I re-read the workflow history and ran the fork verifications myself before opening this.
